### PR TITLE
AAE-5058 Allow new starter artifacts to be published in nexus

### DIFF
--- a/.travis.maven_config.yml
+++ b/.travis.maven_config.yml
@@ -5,4 +5,4 @@ before_install:
   - |-
     mkdir -p $HOME/.m2
     cp settings.xml $HOME/.m2
-    export MAVEN_CLI_OPTS="$MAVEN_CLI_OPTS -B -q -e -fae -V -DinstallAtEnd=true -DdeployAtEnd=true -U"
+    export MAVEN_CLI_OPTS="$MAVEN_CLI_OPTS -B -q -e -fae -V -DinstallAtEnd=true -U"


### PR DESCRIPTION
Eliminate experimental `DeployAtEnd` flag: https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#deployAtEnd
The latest green build of `alfresco-process` didn't deploy any artifact to nexus: https://travis-ci.com/github/Alfresco/alfresco-process/builds/224535976

Actually, none of the artifacts of `alfresco-process` M12 are present in nexus