### PR TITLE
OPSEXP-1266: checkov2 makes sense for lint stages only with python 3.8+

### DIFF
--- a/.travis.checkov_install.yml
+++ b/.travis.checkov_install.yml
@@ -4,9 +4,9 @@ env:
     - CHECKOV_VERSION=${CHECKOV_VERSION:-2.0.795}
 jobs:
   include:
-    - name: checkov
+    - name: pre-commit
       stage: lint
       language: python
       python: 3.9
-      install:
+      before_install:
         - pip install checkov==$CHECKOV_VERSION

--- a/.travis.checkov_install.yml
+++ b/.travis.checkov_install.yml
@@ -2,7 +2,7 @@ language: python
 env:
   global:
     - CHECKOV_VERSION=${CHECKOV_VERSION:-2.0.795}
-jobes:
+jobs:
   include:
     - name: checkov
       stage: lint

--- a/.travis.checkov_install.yml
+++ b/.travis.checkov_install.yml
@@ -1,12 +1,7 @@
 language: python
+python: 3.9
 env:
   global:
     - CHECKOV_VERSION=${CHECKOV_VERSION:-2.0.795}
-jobs:
-  include:
-    - name: pre-commit
-      stage: lint
-      language: python
-      python: 3.9
-      before_install:
-        - pip install checkov==$CHECKOV_VERSION
+before_install:
+  - pip install checkov==$CHECKOV_VERSION

--- a/.travis.checkov_install.yml
+++ b/.travis.checkov_install.yml
@@ -8,5 +8,5 @@ jobs:
       stage: lint
       language: python
       python: 3.9
-before_install:
-  - pip install checkov==$CHECKOV_VERSION
+      install:
+        - pip install checkov==$CHECKOV_VERSION

--- a/.travis.checkov_install.yml
+++ b/.travis.checkov_install.yml
@@ -2,5 +2,11 @@ language: python
 env:
   global:
     - CHECKOV_VERSION=${CHECKOV_VERSION:-2.0.795}
+jobes:
+  include:
+    - name: checkov
+      stage: lint
+      language: python
+      python: 3.9
 before_install:
   - pip install checkov==$CHECKOV_VERSION


### PR DESCRIPTION
Forces checkov2 installation to happen with  python3.9 and avoid running during others stages thatn linters.