### PR TITLE
fix: AAE-7879 use semver to calculate next prerelease

### DIFF
--- a/.github/actions/calculate-next-internal-version/action.yml
+++ b/.github/actions/calculate-next-internal-version/action.yml
@@ -1,5 +1,9 @@
 name: 'Calculate next internal version'
 description: 'Calculate next internal version based on existing tags'
+inputs:
+  next-version:
+    description: 'Next version following the pattern MAJOR.MINOR.PATCH'
+    required: true
 outputs:
   next-prerelease:
     description: "Next prerelease"
@@ -10,3 +14,5 @@ runs:
     - id: next-prerelease-resolver
       run: ${{ github.action_path }}/next-prerelease.sh
       shell: bash
+      env:
+        NEXT_VERSION: ${{inputs.next-version}}

--- a/.github/actions/calculate-next-internal-version/next-prerelease.sh
+++ b/.github/actions/calculate-next-internal-version/next-prerelease.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-CURRENT_YEAR=$(date +%y)
-echo "Year: $CURRENT_YEAR"
-
 echo "Fetching tags ... "
 git fetch --tags
 
-LATEST_MINOR=$(git tag --sort=-creatordate | grep -m 1  "^$CURRENT_YEAR\.[[:digit:]]\{1,2\}\.[[:digit:]]\{1,2\}$" | cat)
 PRERELEASE_LABEL="alpha"
 FIRST_PRERELEASE_SUFFIX="-${PRERELEASE_LABEL}.1"
 
-if [ -n  "$LATEST_MINOR" ]; then
-  echo "Latest minor version found: $LATEST_MINOR"
-  NEXT_MINOR="$(pysemver bump minor "$LATEST_MINOR")"
-  echo "Next minor: $NEXT_MINOR"
-  LATEST_PRERELEASE="$(git tag --sort=-creatordate | grep -m 1  "^$NEXT_MINOR\-$PRERELEASE_LABEL\.[[:digit:]]\{1,4\}$" | cat)"
-  if [ -n "$LATEST_PRERELEASE" ]; then
-    echo "Latest prerelease version found: $LATEST_PRERELEASE"
-    NEXT_PRERELEASE="$(pysemver bump prerelease "$LATEST_PRERELEASE")"
-  else
-    echo "No prerelease found for minor $NEXT_MINOR yet"
-    NEXT_PRERELEASE="$NEXT_MINOR$FIRST_PRERELEASE_SUFFIX"
-  fi
+echo "Next version: $NEXT_VERSION"
+LATEST_PRERELEASE="$(git tag --sort=-creatordate | grep -m 1  "^$NEXT_VERSION\-$PRERELEASE_LABEL\.[[:digit:]]\{1,4\}$" | cat)"
+if [ -n "$LATEST_PRERELEASE" ]; then
+  echo "Latest prerelease version found: $LATEST_PRERELEASE"
+  NEXT_PRERELEASE="$(pysemver bump prerelease "$LATEST_PRERELEASE")"
 else
-  NEXT_PRERELEASE="$CURRENT_YEAR.1.0$FIRST_PRERELEASE_SUFFIX"
-  echo "No minor version found for year '$CURRENT_YEAR'"
+  echo "No prerelease found for version $NEXT_VERSION yet"
+  NEXT_PRERELEASE="$NEXT_VERSION$FIRST_PRERELEASE_SUFFIX"
 fi
 echo "Next prerelease: $NEXT_PRERELEASE"
 echo "::set-output name=next-prerelease::$NEXT_PRERELEASE"


### PR DESCRIPTION
The next version should be provided as input and based on that the next prerelease version is calculated. I.e:
```yaml
uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@revision
    with:
        next-version: 7.2.0
```