### PR TITLE
Do not checkout in pre-commit action

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -8,7 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@master
 ```
 


### PR DESCRIPTION
Initially it looked handy given that pre-commit is often the first step of a job, but unfortunately that will overwrite any previous checkout invocation for which the user may have provided additional parameters.

Required in https://github.com/Alfresco/security-testing-travis/pull/15