### PR TITLE
AAE-8962 fix build for Veracode

### DIFF
--- a/.github/workflows/publish-artifacts-for-veracode.yml
+++ b/.github/workflows/publish-artifacts-for-veracode.yml
@@ -8,7 +8,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: pre-commit
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11


### PR DESCRIPTION
there is no need for running pre-commit, as this is already checked in the main build