### PR TITLE
AAE-9367 fix condition for auto-merge

### DIFF
--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'alfresco-build' && contains( github.event.pull_request.labels.*.name, 'updatebot') }}
+    if: ${{ github.event.pull_request.user.login == 'alfresco-build' && contains( github.event.pull_request.labels.*.name, 'updatebot') }}
     steps:
       - name: Enable auto-merge for propagation Pull Request
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
`github.actor` references the user who triggered the workflow, that could be a different user in case of rebase for instance.
Note that a rebase is mandatory in case where another PR got merged in the main branch in the mean time.
What we are looking is actually the author of the PR, so `github.event.pull_request.user.login`