### PR TITLE
AAE-9367 trigger auto-merge workflow only if the event label matches

### DIFF
--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'alfresco-build' && contains( github.event.pull_request.labels.*.name, 'updatebot') }}
+    if: ${{ github.event.pull_request.user.login == 'alfresco-build' && github.event.label.name == 'updatebot' }}
     steps:
       - name: Enable auto-merge for propagation Pull Request
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Now the workflow will only be triggered when the PR is labeled (instead of PR opened/reopened)