### PR TITLE
AAE-8916 Add the possibility to specify the type of the prerelease

### DIFF
--- a/.github/actions/calculate-next-internal-version/action.yml
+++ b/.github/actions/calculate-next-internal-version/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: The type of the prerelease, i.e. `alpha`, `beta`, `rc`
     required: false
     default: alpha
+  repository-directory:
+    description: "Path to the directory holding the git repository"
+    required: false
 
 outputs:
   next-prerelease:
@@ -24,3 +27,4 @@ runs:
       env:
         NEXT_VERSION: ${{ inputs.next-version }}
         PRERELEASE_TYPE: ${{ inputs.prerelease-type }}
+        REPO_DIR: ${{inputs.repository-directory}}

--- a/.github/actions/calculate-next-internal-version/action.yml
+++ b/.github/actions/calculate-next-internal-version/action.yml
@@ -4,6 +4,11 @@ inputs:
   next-version:
     description: 'Next version following the pattern MAJOR.MINOR.PATCH'
     required: true
+  prerelease-type:
+    description: The type of the prerelease, i.e. `alpha`, `beta`, `rc`
+    required: false
+    default: alpha
+
 outputs:
   next-prerelease:
     description: "Next prerelease"
@@ -18,3 +23,4 @@ runs:
       shell: bash
       env:
         NEXT_VERSION: ${{ inputs.next-version }}
+        PRERELEASE_TYPE: ${{ inputs.prerelease-type }}

--- a/.github/actions/calculate-next-internal-version/next-prerelease.sh
+++ b/.github/actions/calculate-next-internal-version/next-prerelease.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if [ -n "$REPO_DIR" ]
+then
+  cd "$REPO_DIR"
+fi
+
 echo "Fetching tags ... "
 git fetch --tags
 

--- a/.github/actions/calculate-next-internal-version/next-prerelease.sh
+++ b/.github/actions/calculate-next-internal-version/next-prerelease.sh
@@ -4,11 +4,10 @@ set -e
 echo "Fetching tags ... "
 git fetch --tags
 
-PRERELEASE_LABEL="alpha"
-FIRST_PRERELEASE_SUFFIX="-${PRERELEASE_LABEL}.1"
+FIRST_PRERELEASE_SUFFIX="-${PRERELEASE_TYPE}.1"
 
 echo "Next version: $NEXT_VERSION"
-LATEST_PRERELEASE="$(git tag --sort=-creatordate | grep -m 1  "^$NEXT_VERSION\-$PRERELEASE_LABEL\.[[:digit:]]\{1,4\}$" | cat)"
+LATEST_PRERELEASE="$(git tag --sort=-creatordate | grep -m 1  "^$NEXT_VERSION\-$PRERELEASE_TYPE\.[[:digit:]]\{1,4\}$" | cat)"
 if [ -n "$LATEST_PRERELEASE" ]; then
   echo "Latest prerelease version found: $LATEST_PRERELEASE"
   NEXT_PRERELEASE="$(pysemver bump prerelease "$LATEST_PRERELEASE")"


### PR DESCRIPTION
An extra input defines the type of the prerelease. i.e. `alpha` (default), `beta`, `rc`.
It's also possible to define a working directory to point to the git repository.