### PR TITLE
OPSEXP-1545 Fix compose tests for forked PRs

### DIFF
--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         echo "${{ github.event.pull_request.head.repo.fork }}"
       shell: bash
-    - if: '! contains(inputs.compose_file_path, "community") && ! github.event.pull_request.head.repo.fork'
+    - if: ! contains(inputs.compose_file_path, 'community') && ! github.event.pull_request.head.repo.fork
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,14 +24,14 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - if: ${{ inputs.quay_username }} && ${{ inputs.quay_password }}
+    - if: ${{ inputs.quay_username != '' }} && ${{ inputs.quay_password != ''}}
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:
         registry: quay.io
         username: ${{ inputs.QUAY_USERNAME }}
         password: ${{ inputs.QUAY_PASSWORD }}
-    - if: ${{ inputs.docker_username }} && ${{ inputs.docker_password }}
+    - if: ${{ inputs.docker_username != '' }} && ${{ inputs.docker_password != '' }}
       name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,7 +24,11 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - if: ${{ inputs.acs_version != 'community' }} && ! github.event.pull_request.head.repo.fork
+    - name: debug
+      run: |
+        echo "${{ github.event.pull_request.head.repo.fork }}"
+      shell: bash
+    - if: '! contains(inputs.compose_file_path, "community") && ! github.event.pull_request.head.repo.fork'
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:
@@ -38,7 +42,7 @@ runs:
         username: ${{ inputs.DOCKER_USERNAME }}
         password: ${{ inputs.DOCKER_PASSWORD }}
     - name: Run Docker Compose tests
-      if: ${{ inputs.acs_version == 'community' }} || ! github.event.pull_request.head.repo.fork
+      if: contains(inputs.compose_file_path, 'community') || ! github.event.pull_request.head.repo.fork
       run: ${{ github.action_path }}/docker_compose.sh
       shell: bash
       env:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -27,15 +27,19 @@ runs:
     - name: 'debug'
       run: |
         echo "${{ github.event.pull_request.head.repo.fork }}"
+        echo "${{ inputs.quay_username }}: ${{ inputs.quay_username != '' }}"
+        echo "${{ inputs.quay_password }}: ${{ inputs.quay_password != '' }}"
+        echo "${{ inputs.docker_username }}: ${{ inputs.docker_username != '' }}"
+        echo "${{ inputs.docker_password }}: ${{ inputs.docker_password != '' }}"
       shell: bash
-    - if: ${{ inputs.quay_username != '' }} && ${{ inputs.quay_password != ''}}
+    - if: ${{ inputs.quay_username != '' && inputs.quay_password != '' }}
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:
         registry: quay.io
         username: ${{ inputs.QUAY_USERNAME }}
         password: ${{ inputs.QUAY_PASSWORD }}
-    - if: ${{ inputs.docker_username != '' }} && ${{ inputs.docker_password != '' }}
+    - if: ${{ inputs.docker_username != '' && inputs.docker_password != '' }}
       name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         echo "${{ github.event.pull_request.head.repo.fork }}"
       shell: bash
-    - if: ! contains(inputs.compose_file_path, 'community') && ! github.event.pull_request.head.repo.fork
+    - if: ${{ ! contains(inputs.compose_file_path, 'community') }} && ! github.event.pull_request.head.repo.fork
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -29,14 +29,14 @@ runs:
       uses: docker/login-action@v1
       with:
         registry: quay.io
-        username: ${{ inputs.QUAY_USERNAME }}
-        password: ${{ inputs.QUAY_PASSWORD }}
+        username: ${{ inputs.quay_username }}
+        password: ${{ inputs.quay_password }}
     - if: ${{ inputs.docker_username != '' && inputs.docker_password != '' }}
       name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ inputs.DOCKER_USERNAME }}
-        password: ${{ inputs.DOCKER_PASSWORD }}
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
     - name: Run Docker Compose tests
       run: ${{ github.action_path }}/docker_compose.sh
       shell: bash

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,14 +24,14 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - if: ${{ ! inputs.quay_username }} && ${{ ! inputs.quay_password }}
+    - if: ${{ inputs.quay_username }} && ${{ inputs.quay_password }}
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:
         registry: quay.io
         username: ${{ inputs.QUAY_USERNAME }}
         password: ${{ inputs.QUAY_PASSWORD }}
-    - if: ${{ ! inputs.docker_username }} && ${{ ! inputs.docker_password }}
+    - if: ${{ inputs.docker_username }} && ${{ inputs.docker_password }}
       name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -27,10 +27,6 @@ runs:
     - name: 'debug'
       run: |
         echo "${{ github.event.pull_request.head.repo.fork }}"
-        echo "${{ inputs.quay_username }}: ${{ inputs.quay_username != '' }}"
-        echo "${{ inputs.quay_password }}: ${{ inputs.quay_password != '' }}"
-        echo "${{ inputs.docker_username }}: ${{ inputs.docker_username != '' }}"
-        echo "${{ inputs.docker_password }}: ${{ inputs.docker_password != '' }}"
       shell: bash
     - if: ${{ inputs.quay_username != '' && inputs.quay_password != '' }}
       name: Login to Quay.io

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,30 +24,20 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - if: '! github.event.pull_request.head.repo.fork'
-      name: debug
-      run: |
-        echo "is not from fork"
-      shell: bash
-    - if: github.event.pull_request.head.repo.fork
-      run: |
-        echo "is from fork"
-      shell: bash
-    - if: ${{ ! contains(inputs.compose_file_path, 'community') }} && ! github.event.pull_request.head.repo.fork
+    - if: ${{ ! inputs.quay_username }} && ${{ ! inputs.quay_password }}
       name: Login to Quay.io
       uses: docker/login-action@v1
       with:
         registry: quay.io
         username: ${{ inputs.QUAY_USERNAME }}
         password: ${{ inputs.QUAY_PASSWORD }}
-    - if: '! github.event.pull_request.head.repo.fork'
+    - if: ${{ ! inputs.docker_username }} && ${{ ! inputs.docker_password }}
       name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{ inputs.DOCKER_USERNAME }}
         password: ${{ inputs.DOCKER_PASSWORD }}
     - name: Run Docker Compose tests
-      if: contains(inputs.compose_file_path, 'community') || ! github.event.pull_request.head.repo.fork
       run: ${{ github.action_path }}/docker_compose.sh
       shell: bash
       env:

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,9 +24,14 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: debug
+    - if: '! github.event.pull_request.head.repo.fork'
+      name: debug
       run: |
-        echo "${{ github.event.pull_request.head.repo.fork }}"
+        echo "is not from fork"
+      shell: bash
+    - if: github.event.pull_request.head.repo.fork
+      run: |
+        echo "is from fork"
       shell: bash
     - if: ${{ ! contains(inputs.compose_file_path, 'community') }} && ! github.event.pull_request.head.repo.fork
       name: Login to Quay.io

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,10 +24,6 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: 'debug'
-      run: |
-        echo "${{ github.event.pull_request.head.repo.fork }}"
-      shell: bash
     - if: ${{ inputs.quay_username != '' && inputs.quay_password != '' }}
       name: Login to Quay.io
       uses: docker/login-action@v1

--- a/.github/actions/dbp-charts/verify-compose/action.yml
+++ b/.github/actions/dbp-charts/verify-compose/action.yml
@@ -24,6 +24,10 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: 'debug'
+      run: |
+        echo "${{ github.event.pull_request.head.repo.fork }}"
+      shell: bash
     - if: ${{ inputs.quay_username != '' }} && ${{ inputs.quay_password != ''}}
       name: Login to Quay.io
       uses: docker/login-action@v1


### PR DESCRIPTION
Now the action relies on passing valid container registry credentials instead of checking the github event type.