### PR TITLE
OPSEXP-1746: add an helm-unittest action

### DIFF
--- a/.github/actions/helm-unit-tests/action.yml
+++ b/.github/actions/helm-unit-tests/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         set -e
         if [ -d tests ]; then echo "${{ inputs.chart-dir }}: Unit tests"
-          helm plugin install https://github.com/vbehar/helm3-unittest
+          helm plugin install https://github.com/vbehar/helm3-unittest --version ${{ inputs.plugin_version }}
           helm dep up
           helm unittest --color .
         else

--- a/.github/actions/helm-unit-tests/action.yml
+++ b/.github/actions/helm-unit-tests/action.yml
@@ -1,0 +1,34 @@
+---
+name: Helm Unit tests
+description: >
+  Look for helm-unittest "test" folder and run the tests
+inputs:
+  plugin_version:
+    description: version of the helm-unittest plugin to install
+    required: false
+    default: v1.0.16
+  chart-dir:
+    description: root folder of the chart
+    required: false
+    default: .
+  chart-type:
+    description: >
+      type of chart (application or library, empty assumes application)
+    required: false
+    default: application
+runs:
+  using: composite
+  steps:
+    - name: Run Helm Unit tests
+      shell: bash
+      working-directory: ${{ inputs.chart-dir }}
+      if: ${{ inputs.chart-type }} != 'library'
+      run: |
+        set -e
+        if [ -d tests ]; then echo "${{ inputs.chart-dir }}: Unit tests"
+          helm plugin install https://github.com/vbehar/helm3-unittest
+          helm dep up
+          helm unittest --color .
+        else
+          echo "No Unit tests implemented for ${{ inputs.chart-dir }} chart!"
+        fi

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Shared [Travis CI](https://travis-ci.com/), [GitHub Actions](https://docs.github
     - [maven-release](#maven-release)
     - [nexus-create-staging](#nexus-create-staging)
     - [helm-package-chart](#helm-package-chart)
+    - [helm-unit-test](#helm-unit-test)
     - [helm-parse-next-release](#helm-parse-next-release)
     - [helm-release-and-publish](#helm-release-and-publish)
     - [pre-commit](#pre-commit)
@@ -517,6 +518,18 @@ The resulting staging repository will be available in the output named `staging-
           nexus-profile-id: "${{ secrets.NEXUS_ACTIVITI7_PROFILE_ID }}"
           nexus-username: "${{ secrets.NEXUS_USERNAME }}"
           nexus-password: "${{ secrets.NEXUS_PASSWORD }}"
+```
+
+### helm-unit-test
+
+Looks for Helm unit tests written using [helm3-unittest](https://github.com/vbehar/helm3-unittest/blob/master/DOCUMENT.md).
+
+```yaml
+     - uses: >-
+         Alfresco/alfresco-build-tools/.github/actions/helm-unit-tests@ref
+       with:
+         chart-dir: charts/myapp
+         chart-type: application
 ```
 
 ### helm-package-chart


### PR DESCRIPTION
Ref: OPSEXP-1746

installs `helm-unittest` plugin and runs tests if a `tests` folder exists