### PR TITLE
OPSEXP-1772 Migrate to new way to set outputs in our actions

### DIFF
--- a/.github/actions/automate-dependabot/action.yml
+++ b/.github/actions/automate-dependabot/action.yml
@@ -24,9 +24,9 @@ runs:
       run: |
         if [[ $EVENT_NAME == 'pull_request' && $PR_LOGIN == 'dependabot[bot]' ]]
         then
-            echo "::set-output name=continue::true"
+            echo "continue=true" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=continue::false"
+            echo "continue=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Dependabot metadata

--- a/.github/actions/automate-propagation/action.yml
+++ b/.github/actions/automate-propagation/action.yml
@@ -29,9 +29,9 @@ runs:
       run: |
         if [[ $LABEL == 'updatebot' && $PR_LOGIN == 'alfresco-build' ]]
         then
-            echo "::set-output name=continue::true"
+            echo "continue=true" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=continue::false"
+            echo "continue=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Enable auto-merge for propagation Pull Request

--- a/.github/actions/calculate-next-internal-version/next-prerelease.sh
+++ b/.github/actions/calculate-next-internal-version/next-prerelease.sh
@@ -21,4 +21,4 @@ else
   NEXT_PRERELEASE="$NEXT_VERSION$FIRST_PRERELEASE_SUFFIX"
 fi
 echo "Next prerelease: $NEXT_PRERELEASE"
-echo "::set-output name=next-prerelease::$NEXT_PRERELEASE"
+echo "next-prerelease=$NEXT_PRERELEASE" >> $GITHUB_OUTPUT

--- a/.github/actions/git-check-existing-tag/action.yml
+++ b/.github/actions/git-check-existing-tag/action.yml
@@ -30,8 +30,8 @@ runs:
         if git ls-remote --exit-code --tags origin "$TAG"
         then
           echo "Tag $TAG exists already"
-          echo "::set-output name=tag-exists::true"
+          echo "tag-exists=true" >> $GITHUB_OUTPUT
         else
           echo "Tag $TAG does not exist"
-          echo "::set-output name=tag-exists::false"
+          echo "tag-exists=false" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/git-latest-tag/action.yml
+++ b/.github/actions/git-latest-tag/action.yml
@@ -30,4 +30,4 @@ runs:
         git fetch --tags
         TAG=$(git tag --list "$PATTERN" --sort=-creatordate | head -n 1)
         echo "Latest tag for the pattern $PATTERN is $TAG"
-        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/.github/actions/helm-package-chart/action.yml
+++ b/.github/actions/helm-package-chart/action.yml
@@ -30,8 +30,8 @@ runs:
         helm package ${{ inputs.chart-dir }}
         PACKAGE_FILE=$(ls | grep *\.tgz)
         PACKAGE_FILE_PATH="$(pwd)/$PACKAGE_FILE"
-        echo "::set-output name=package-file::$PACKAGE_FILE"
-        echo "::set-output name=package-file-path::$PACKAGE_FILE_PATH"
+        echo "package-file=$PACKAGE_FILE" >> $GITHUB_OUTPUT
+        echo "package-file-path=$PACKAGE_FILE_PATH" >> $GITHUB_OUTPUT
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/.github/actions/helm-parse-next-release/action.yml
+++ b/.github/actions/helm-parse-next-release/action.yml
@@ -29,4 +29,4 @@ runs:
 
         NEXT_VERSION=$(yq e '.version' ${{ inputs.chart-dir }}/Chart.yaml | grep -o "[0-9]*\.[0-9]*.[0-9]*")
         echo "Next final version: $NEXT_VERSION"
-        echo "::set-output name=next-release::$NEXT_VERSION"
+        echo "next-release=$NEXT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/actions/load-release-descriptor/action.yml
+++ b/.github/actions/load-release-descriptor/action.yml
@@ -65,13 +65,13 @@ runs:
           VERSION=$VERSION-mock
         fi
 
-        echo "::set-output name=branch::$BRANCH"
-        echo "::set-output name=version::$VERSION"
-        echo "::set-output name=next-version::$NEXT_VERSION"
-        echo "::set-output name=mock::$MOCK"
-        echo "::set-output name=activiti-tag::$ACTIVITI_BASE_TAG"
-        echo "::set-output name=activiti-cloud-tag::$ACTIVITI_CLOUD_BASE_TAG"
-        echo "::set-output name=activiti-cloud-application-tag::$ACTIVITI_CLOUD_APP_BASE_TAG"
-        echo "::set-output name=common-chart-tag::$COMMON_CHART_BASE_TAG"
-        echo "::set-output name=full-chart-tag::$FULL_CHART_BASE_TAG"
-        echo "::set-output name=staging-repository::$STAGING_REPOSITORY"
+        echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "next-version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+        echo "mock=$MOCK" >> $GITHUB_OUTPUT
+        echo "activiti-tag=$ACTIVITI_BASE_TAG" >> $GITHUB_OUTPUT
+        echo "activiti-cloud-tag=$ACTIVITI_CLOUD_BASE_TAG" >> $GITHUB_OUTPUT
+        echo "activiti-cloud-application-tag=$ACTIVITI_CLOUD_APP_BASE_TAG" >> $GITHUB_OUTPUT
+        echo "common-chart-tag=$COMMON_CHART_BASE_TAG" >> $GITHUB_OUTPUT
+        echo "full-chart-tag=$FULL_CHART_BASE_TAG" >> $GITHUB_OUTPUT
+        echo "staging-repository=$STAGING_REPOSITORY" >> $GITHUB_OUTPUT

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -100,9 +100,9 @@ runs:
       run: |
         if [ $DO_PUSH == 'true' ]
         then
-          echo "::set-output name=command::deploy"
+          echo "command=deploy" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=command::verify"
+          echo "command=verify" >> $GITHUB_OUTPUT
         fi
       env:
         DO_PUSH: ${{ github.event_name == 'push' }}
@@ -125,7 +125,7 @@ runs:
       run: |
         if [ $DO_PUSH == 'true' ]
         then
-          echo "::set-output name=command::--push"
+          echo "command=--push" >> $GITHUB_OUTPUT
         fi
       env:
         DO_PUSH: ${{ github.event_name == 'push' }}

--- a/.github/actions/nexus-create-staging/action.yml
+++ b/.github/actions/nexus-create-staging/action.yml
@@ -55,4 +55,4 @@ runs:
           echo "Reusing existing staging repository $NEXUS_STAGING_REPOSITORY"
         fi
 
-        echo "::set-output name=staging-repository::$NEXUS_STAGING_REPOSITORY"
+        echo "staging-repository=$NEXUS_STAGING_REPOSITORY" >> $GITHUB_OUTPUT

--- a/.github/actions/publish-helm-chart/action.yml
+++ b/.github/actions/publish-helm-chart/action.yml
@@ -43,7 +43,7 @@ runs:
       run: |
         if [ -n "$CHARTS_REPO_BASE_URL" ]
         then
-            echo "::set-output name=result::--url $CHARTS_REPO_BASE_URL"
+            echo "result=--url $CHARTS_REPO_BASE_URL" >> $GITHUB_OUTPUT
         fi
 
     - name: Build destination path
@@ -54,9 +54,9 @@ runs:
       run: |
         if [ -n "$CHARTS_REPO_SUBFOLDER" ]
         then
-            echo "::set-output name=result::$CHARTS_REPO_SUBFOLDER"
+            echo "result=$CHARTS_REPO_SUBFOLDER" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=result::."
+            echo "result=." >> $GITHUB_OUTPUT
         fi
 
 

--- a/.github/actions/resolve-preview-name/resolve-preview-name.sh
+++ b/.github/actions/resolve-preview-name/resolve-preview-name.sh
@@ -3,4 +3,4 @@ set -e
 
 test "${GITHUB_PR_NUMBER}" && PREVIEW_NAME=pr-${GITHUB_PR_NUMBER} || PREVIEW_NAME=gh-$GITHUB_RUN_NUMBER
 echo Preview name: "$PREVIEW_NAME"
-echo "::set-output name=preview-name::$PREVIEW_NAME"
+echo "preview-name=$PREVIEW_NAME" >> $GITHUB_OUTPUT

--- a/.github/actions/send-slack-notification/action.yml
+++ b/.github/actions/send-slack-notification/action.yml
@@ -27,9 +27,9 @@ runs:
       run: |
         if [ -n "$INPUT_COLOR" ]
         then
-          echo "::set-output name=result::$INPUT_COLOR"
+          echo "result=$INPUT_COLOR" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=result::#A30200"
+          echo "result=#A30200" >> $GITHUB_OUTPUT
         fi
 
     - name: Compute small sha
@@ -39,7 +39,7 @@ runs:
         GITHUB_LONG_SHA: ${{ github.sha }}
       run: |
         SMALL_SHA=${GITHUB_LONG_SHA:0:6}
-        echo "::set-output name=result::$SMALL_SHA"
+        echo "result=$SMALL_SHA" >> $GITHUB_OUTPUT
 
     - name: Compute message
       id: compute-message
@@ -59,7 +59,7 @@ runs:
             BLOCK_MESSAGE=${BLOCK_MESSAGE:-${{ github.event.head_commit.message }}}
             ;;
         esac
-        echo "::set-output name=result::${BLOCK_MESSAGE}"
+        echo "result=${BLOCK_MESSAGE}" >> $GITHUB_OUTPUT
 
     - name: Send slack notification
       id: slack

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         NEXT_VERSION=$(yq -p=xml e '.project.version' pom.xml | grep -o "[0-9]*\.[0-9]*.[0-9]*")
         echo "Next final version: $NEXT_VERSION"
-        echo "::set-output name=result::$NEXT_VERSION"
+        echo "result=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
     - id: next-prerelease-resolver
       name: Calculate next internal release


### PR DESCRIPTION
Support for the `set-output` [replacement](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)

Done with search `echo "::set-output name=(.*)::(.*)"` and replace with `echo "$1=$2" >> $GITHUB_OUTPUT` in vscode

OPSEXP-1772