### PR TITLE
fix(jx-updatebot-pr): update release binary version to 0.3.13 

### DIFF
--- a/.github/actions/jx-updatebot-pr/action.yml
+++ b/.github/actions/jx-updatebot-pr/action.yml
@@ -73,7 +73,7 @@ inputs:
   jx-updatebot-release:
     description: the version of jx-updatebot release.
     required: false
-    default: '0.3.3'
+    default: '0.3.13'
   working-directory:
     required: false
     description: project root directory. Defaults to '.'

--- a/.github/actions/jx-updatebot-pr/action.yml
+++ b/.github/actions/jx-updatebot-pr/action.yml
@@ -71,7 +71,7 @@ inputs:
     required: false
     default: ''
   jx-updatebot-release:
-    description: the version of jx-updatebot release.
+    description: the version of jx-updatebot release binary.
     required: false
     default: '0.3.13'
   working-directory:


### PR DESCRIPTION
This PR updates x-updatebot-pr release binary version to 0.3.13 with the fix https://github.com/jenkins-x-plugins/jx-updatebot/pull/57

This will fix propagation jobs in https://github.com/Alfresco/alfresco-process/actions/runs/3299923763/jobs/5444513209