### PR TITLE
AAE-10136: fix helm publish workflow by downloading package previousl…

### DIFF
--- a/.github/actions/helm-package-chart/action.yml
+++ b/.github/actions/helm-package-chart/action.yml
@@ -11,6 +11,9 @@ outputs:
   package-file:
     description: The name of the generated package file. It's uploaded as an artifact and can be downloaded using actions/download-artifact
     value: ${{ steps.package.outputs.package-file }}
+  package-file-path:
+    description: The path of the generated package file.
+    value: ${{ steps.package.outputs.package-file-path }}
 
 runs:
   using: composite

--- a/.github/actions/helm-publish-chart/action.yml
+++ b/.github/actions/helm-publish-chart/action.yml
@@ -104,7 +104,7 @@ runs:
         then
           echo "result=$INPUT_MESSAGE" >> $GITHUB_OUTPUT
         else
-          RELEASE_PACKAGE_NAME=basename $RELEASE_PACKAGE_PATH
+          RELEASE_PACKAGE_NAME=$(basename $RELEASE_PACKAGE_PATH)
           echo "result=Release $RELEASE_PACKAGE_NAME" >> $GITHUB_OUTPUT
         fi
 

--- a/.github/actions/helm-publish-chart/action.yml
+++ b/.github/actions/helm-publish-chart/action.yml
@@ -4,6 +4,9 @@ inputs:
   chart-package:
     description: "The name of the packaged chart been added to the repository. I.e. common-x.y.z.tgz"
     required: true
+  chart-package-path:
+    description: "The path of the packaged chart been added to the repository. I.e. common-x.y.z.tgz. Used the package name if not set."
+    required: false
   helm-charts-repo:
     description: "The name of the repository where the package will be added"
     required: true
@@ -86,10 +89,16 @@ runs:
       env:
         BASE_URL: ${{ steps.build-base-url-option.outputs.result }}
         SUB_REPO: ${{ steps.build-destination-path.outputs.result }}
+        RELEASE_PACKAGE_NAME: ${{ inputs.chart-package }}
+        RELEASE_PACKAGE_PATH: ${{ inputs.chart-package-path }}
       run: |
           mkdir $RANDOM_PATH
-          RELEASE_PACKAGE_NAME=${{ inputs.chart-package }}
-          cp "$RELEASE_PACKAGE_NAME" $RANDOM_PATH
+          if [ -n "$RELEASE_PACKAGE_PATH" ]
+          then
+            cp "$RELEASE_PACKAGE_PATH" $RANDOM_PATH
+          else
+            cp "$RELEASE_PACKAGE_NAME" $RANDOM_PATH
+          fi
           helm repo index $RANDOM_PATH $BASE_URL --merge $CHECKOUT_PATH/$SUB_REPO/index.yaml
           mv $RANDOM_PATH/* $CHECKOUT_PATH/$SUB_REPO
           rm -rf $RANDOM_PATH

--- a/.github/actions/helm-publish-chart/action.yml
+++ b/.github/actions/helm-publish-chart/action.yml
@@ -2,11 +2,8 @@ name: "Add package to helm repository"
 description: "Add a new package to the helm repository, updates the index file and commit the change"
 inputs:
   chart-package:
-    description: "The name of the packaged chart been added to the repository. I.e. common-x.y.z.tgz"
+    description: "The path to the packaged chart to add to the repository. I.e. path/too/common-x.y.z.tgz"
     required: true
-  chart-package-path:
-    description: "The path of the packaged chart been added to the repository. I.e. common-x.y.z.tgz. Used the package name if not set."
-    required: false
   helm-charts-repo:
     description: "The name of the repository where the package will be added"
     required: true
@@ -89,31 +86,25 @@ runs:
       env:
         BASE_URL: ${{ steps.build-base-url-option.outputs.result }}
         SUB_REPO: ${{ steps.build-destination-path.outputs.result }}
-        RELEASE_PACKAGE_NAME: ${{ inputs.chart-package }}
-        RELEASE_PACKAGE_PATH: ${{ inputs.chart-package-path }}
+        RELEASE_PACKAGE_PATH: ${{ inputs.chart-package }}
       run: |
-          mkdir $RANDOM_PATH
-          if [ -n "$RELEASE_PACKAGE_PATH" ]
-          then
-            cp "$RELEASE_PACKAGE_PATH" $RANDOM_PATH
-          else
-            cp "$RELEASE_PACKAGE_NAME" $RANDOM_PATH
-          fi
-          helm repo index $RANDOM_PATH $BASE_URL --merge $CHECKOUT_PATH/$SUB_REPO/index.yaml
-          mv $RANDOM_PATH/* $CHECKOUT_PATH/$SUB_REPO
-          rm -rf $RANDOM_PATH
+        cp "$RELEASE_PACKAGE_PATH" $RANDOM_PATH
+        helm repo index $RANDOM_PATH $BASE_URL --merge $CHECKOUT_PATH/$SUB_REPO/index.yaml
+        mv $RANDOM_PATH/* $CHECKOUT_PATH/$SUB_REPO
+        rm -rf $RANDOM_PATH
 
     - name: Compute git commit message
       id: compute-git-commit-message
       shell: bash
       env:
         INPUT_MESSAGE: ${{ inputs.git-message }}
-        RELEASE_PACKAGE_NAME: ${{ inputs.chart-package }}
+        RELEASE_PACKAGE_PATH: ${{ inputs.chart-package }}
       run: |
         if [ -n "$INPUT_MESSAGE" ]
         then
           echo "result=$INPUT_MESSAGE" >> $GITHUB_OUTPUT
         else
+          RELEASE_PACKAGE_NAME=basename $RELEASE_PACKAGE_PATH
           echo "result=Release $RELEASE_PACKAGE_NAME" >> $GITHUB_OUTPUT
         fi
 

--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -82,6 +82,5 @@ runs:
       with:
         helm-charts-repo: ${{inputs.helm-repository}}
         helm-charts-repo-branch: ${{ inputs.helm-repository-branch }}
-        chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
-        chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
+        chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
         token: ${{ inputs.helm-repository-token }}

--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -76,11 +76,6 @@ runs:
       shell: bash
       run: git push origin $VERSION
 
-    - uses: actions/download-artifact@v3
-      if: steps.check-tag.outputs.exists == 'false'
-      with:
-        name: ${{ steps.package-helm-chart.outputs.package-file }}
-
     - name: Publish Helm chart
       if: steps.check-tag.outputs.exists == 'false'
       uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.20.1
@@ -88,4 +83,5 @@ runs:
         helm-charts-repo: ${{inputs.helm-repository}}
         helm-charts-repo-branch: ${{ inputs.helm-repository-branch }}
         chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
+        chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
         token: ${{ inputs.helm-repository-token }}

--- a/.github/workflows/helm-publish-new-package-version.yml
+++ b/.github/workflows/helm-publish-new-package-version.yml
@@ -76,6 +76,10 @@ jobs:
       - name: Push tag
         run: git push origin $VERSION
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ steps.package-helm-chart.outputs.package-file }}
+
       - name: Publish Helm chart
         uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.20.1
         with:

--- a/.github/workflows/helm-publish-new-package-version.yml
+++ b/.github/workflows/helm-publish-new-package-version.yml
@@ -76,15 +76,12 @@ jobs:
       - name: Push tag
         run: git push origin $VERSION
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ steps.package-helm-chart.outputs.package-file }}
-
       - name: Publish Helm chart
         uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.20.1
         with:
             helm-charts-repo: ${{ inputs.helm-charts-repo }}
             helm-charts-repo-branch: ${{ inputs.helm-charts-repo-branch }}
             chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
+            chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
             token: ${{ secrets.BOT_GITHUB_TOKEN }}
             git-username: ${{ secrets.BOT_GITHUB_USERNAME }}

--- a/.github/workflows/helm-publish-new-package-version.yml
+++ b/.github/workflows/helm-publish-new-package-version.yml
@@ -81,7 +81,6 @@ jobs:
         with:
             helm-charts-repo: ${{ inputs.helm-charts-repo }}
             helm-charts-repo-branch: ${{ inputs.helm-charts-repo-branch }}
-            chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
-            chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
+            chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
             token: ${{ secrets.BOT_GITHUB_TOKEN }}
             git-username: ${{ secrets.BOT_GITHUB_USERNAME }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -531,8 +531,7 @@ Publishes a new helm chart package (`.tgz`) to a helm chart repository
         with:
           helm-charts-repo: Activiti/activiti-cloud-helm-charts
           helm-charts-repo-branch: gh-pages
-          chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
-          chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
+          chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
           token: ${{ secrets.BOT_GITHUB_TOKEN}}
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -501,7 +501,7 @@ Run `helm upgrade --dryn-run` on the specified chart
 ### helm-package-chart
 
 Packages a helm chart into a `.tgz` file and provides the name of the file produced in the output named `package-file`.
-The packaged file is also updated as an artifact and can be downloaded using `actions/download-artifact`.
+The packaged file is also uploaded as an artifact and can be downloaded using `actions/download-artifact`.
 
 ```yaml
     - uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@ref

--- a/docs/README.md
+++ b/docs/README.md
@@ -500,7 +500,7 @@ Run `helm upgrade --dryn-run` on the specified chart
 
 ### helm-package-chart
 
-Packages a helm chart into a `.tgz` file and provides the name of the file produced in the output named `package-file`.
+Packages a helm chart into a `.tgz` file and provides the name of the file produced in the output named `package-file`, and its path in the output named `package-file-path`.
 The packaged file is also uploaded as an artifact and can be downloaded using `actions/download-artifact`.
 
 ```yaml
@@ -532,6 +532,7 @@ Publishes a new helm chart package (`.tgz`) to a helm chart repository
           helm-charts-repo: Activiti/activiti-cloud-helm-charts
           helm-charts-repo-branch: gh-pages
           chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
+          chart-package-path: ${{ steps.package-helm-chart.outputs.package-file-path }}
           token: ${{ secrets.BOT_GITHUB_TOKEN}}
 ```
 


### PR DESCRIPTION
…y produced

The helm-package-chart action is no longer putting the package in current directory -> it needs to be downloaded so that it can be used by the helm-publish-chart action.