### PR TITLE
Fix failure in maven-deploy-file

### DIFF
--- a/.github/actions/maven-deploy-file/action.yml
+++ b/.github/actions/maven-deploy-file/action.yml
@@ -71,7 +71,7 @@ runs:
       run: |
         OPTIONAL_ARGS=""
         if [[ -n "${{ inputs.files }}" && -n "${{ inputs.classifiers }}" && -n "${{ inputs.types }}" ]]; then
-          OPTIONAL_ARGS='-Dfiles="{{ inputs.files }}" -Dclassifiers="${{ inputs.classifiers }}" -Dtypes="${{ inputs.types }}"'
+          OPTIONAL_ARGS='-Dfiles="${{ inputs.files }}" -Dclassifiers="${{ inputs.classifiers }}" -Dtypes="${{ inputs.types }}"'
         fi
         mvn deploy:deploy-file -B \
           -DgroupId=${{ inputs.group-id }} \


### PR DESCRIPTION
```
Error:  The goal you specified requires a project to execute but there is no POM in this directory (/home/runner/work/imagemagick-build/imagemagick-build). Please verify you invoked Maven from the correct directory. -> [Help 1]
```

https://github.com/Alfresco/imagemagick-build/actions/runs/3436052143/jobs/5729132434#step:7:39