### PR TITLE
OPSEXP-1833 Really fix maven-deploy-file

### DIFF
--- a/.github/actions/maven-deploy-file/action.yml
+++ b/.github/actions/maven-deploy-file/action.yml
@@ -71,7 +71,7 @@ runs:
       run: |
         OPTIONAL_ARGS=""
         if [[ -n "${{ inputs.files }}" && -n "${{ inputs.classifiers }}" && -n "${{ inputs.types }}" ]]; then
-          OPTIONAL_ARGS='-Dfiles="${{ inputs.files }}" -Dclassifiers="${{ inputs.classifiers }}" -Dtypes="${{ inputs.types }}"'
+          OPTIONAL_ARGS='-Dfiles=${{ inputs.files }} -Dclassifiers=${{ inputs.classifiers }} -Dtypes=${{ inputs.types }}'
         fi
         mvn deploy:deploy-file -B \
           -DgroupId=${{ inputs.group-id }} \


### PR DESCRIPTION
OPSEXP-1833

can't find a proper way to build a command line with arguments that get escaped - so for now I prefer to avoid using double quotes and at least it will work if argument values doesn't contains a space.