### PR TITLE
Update check-jsonschema usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/setup-jx-release-version
       - uses: ./.github/actions/setup-kubepug
       - uses: ./.github/actions/rancher
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           rancher-url: 'https://rancher2.envalfresco.com'
           rancher-access-key: ${{ secrets.RANCHER2_ACCESS_KEY }}
@@ -36,7 +36,7 @@ jobs:
           cluster-name: "fake_cluster"
           action: "detach"
       - uses: ./.github/actions/setup-rancher-cli
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           url: ${{ secrets.RANCHER2_URL }}
           access-key: ${{ secrets.RANCHER2_ACCESS_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,9 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.15.0
+    rev: 0.19.2
     hooks:
+      - id: check-dependabot
       - id: check-github-actions
       - id: check-github-workflows
       - id: check-travis


### PR DESCRIPTION
- Update to v0.19.2 (latest)
- Add check-dependabot to validate dependabot config

---

👋 Hi there, `check-jsonschema` maintainer here!

I received a PR in reference to #178 on this repo, and the relevant fix has already been included and released in the latest `check-jsonschema` version (v0.19.2). I noticed that this repo is on a somewhat older version of the hook, so it seemed like a nice/friendly thing to drop a PR with the relevant update.

I recommend using `pre-commit autoupdate` regularly, or using pre-commit.ci for its autoupdate functionality, as it will help you stay up-to-date.