### PR TITLE
OPSEXP-1581 Bump helm-docs default version to v1.11.0

### DIFF
--- a/.github/actions/setup-helm-docs/action.yml
+++ b/.github/actions/setup-helm-docs/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Version of helm-docs'
     required: false
-    default: 1.10.0
+    default: 1.11.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
OPSEXP-1581

beware that this will trigger a pre-commit failure because helm-docs put the version in the footer of the generated markdown