### PR TITLE
fix(AAE-11371): update helm-release-and-publish input params 

### DIFF
--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -29,6 +29,10 @@ inputs:
   git-username:
     description: 'The username to commit on the git repositories'
     required: true
+  do-push:
+    description: "If 'true', changes will be pushed ('false' can be used for PRs)"
+    default: 'true'
+    required: false
 
 runs:
   using: composite
@@ -77,7 +81,7 @@ runs:
         chart-repository-dir: ${{ inputs.chart-repository-dir }}
 
     - name: Push tag
-      if: steps.check-tag.outputs.exists == 'false'
+      if: ${{ steps.check-tag.outputs.exists == 'false' && inputs.do-push == 'true' }}
       working-directory: ${{ inputs.chart-repository-dir }}
       shell: bash
       run: git push origin $VERSION
@@ -92,3 +96,4 @@ runs:
         helm-charts-repo-base-url: ${{ inputs.helm-repository-base-url }}
         chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
         token: ${{ inputs.helm-repository-token }}
+        do-push: ${{ inputs.do-push }}

--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -17,6 +17,12 @@ inputs:
   helm-repository-branch:
     description: 'Branch on the charts repository'
     required: false
+  helm-repository-subfolder:
+    description: 'The name of the subfolder inside the charts repository where the package should be added'
+    required: false
+  helm-repository-base-url:
+    description: 'Helm chart repo base url'
+    required: true
   helm-repository-token:
     description: 'The Github token to checkout the charts repository'
     required: true
@@ -82,5 +88,7 @@ runs:
       with:
         helm-charts-repo: ${{inputs.helm-repository}}
         helm-charts-repo-branch: ${{ inputs.helm-repository-branch }}
+        helm-charts-repo-subfolder: ${{ inputs.helm-repository-subfolder }}
+        helm-charts-repo-base-url: ${{ inputs.helm-repository-base-url }}
         chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
         token: ${{ inputs.helm-repository-token }}

--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
   helm-repository-base-url:
     description: 'Helm chart repo base url'
-    required: true
+    required: false
   helm-repository-token:
     description: 'The Github token to checkout the charts repository'
     required: true


### PR DESCRIPTION
This PR adds missing input params to helm-release-and-publish action to be able to reuse it in https://github.com/Alfresco/alfresco-process-infrastructure-deployment/pull/825