### PR TITLE
AAE-11373 add possibility to skip docker build

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -23,16 +23,16 @@ inputs:
     required: true
   quay-username:
     description: Quay.io user name
-    required: true
+    required: false
   quay-password:
     description: Quay.io password
-    required: true
+    required: false
   docker-username:
     description: Docker.io user name
-    required: true
+    required: false
   docker-password:
     description: Docker.io password
-    required: true
+    required: false
   git-username:
     description: The username to commit on the git repository
     required: true
@@ -80,7 +80,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && inputs.docker-username != ''
       uses: docker/login-action@v2
       with:
         registry: docker.io
@@ -88,6 +88,7 @@ runs:
         password: ${{ inputs.docker-password }}
 
     - name: Login to Quay.io Docker Registry
+      if: inputs.quay-username != ''
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -133,8 +134,13 @@ runs:
     - name: Docker Build (and maybe Push)
       shell: bash
       run: |
-        TAG="${TAG:-$(echo ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} | sed -e 's/[^-_.[:alnum:]]/_/g')}"
-        sh ./build-and-push-docker-images.sh
+        if [ -f build-and-push-docker-images.sh ]
+        then
+          TAG="${TAG:-$(echo ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} | sed -e 's/[^-_.[:alnum:]]/_/g')}"
+          sh ./build-and-push-docker-images.sh
+        else
+          echo File build-and-push-docker-images.sh not found. Skipping docker build...
+        fi
       env:
         PUSH_OPTION: ${{ steps.define_docker_push.outputs.command }}
         TAG: ${{env.VERSION}}


### PR DESCRIPTION
Acceptance tests does not produce any docker images, so we need to be able to skip this step