### PR TITLE
AAE-11711: add text on slack notif payload

### DIFF
--- a/.github/actions/send-slack-notification/action.yml
+++ b/.github/actions/send-slack-notification/action.yml
@@ -87,6 +87,7 @@ runs:
         channel-id: "${{ inputs.channel-id }}"
         payload: |
           {
+            "text": "Notify on ${{ env.EVENT_OUTPUT }} on branch <${{ env.REPO_URL }}/tree/${{ env.BRANCH_NAME }}|`${{ env.BRANCH_NAME }}`>",
             "attachments": [
               {
                 "color": "${{ env.COLOR }}",
@@ -101,20 +102,7 @@ runs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*<${{ env.ACTOR_URL }}|${{ github.actor }}>*"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "section",
-                    "fields": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Repository*\n<${{ env.REPO_URL }}|${{ github.repository }}>"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Event*\n${{ env.EVENT_OUTPUT }} on <${{ env.REPO_URL }}/tree/${{ env.BRANCH_NAME }}|`${{ env.BRANCH_NAME }}`>"
+                        "text": "<${{ env.ACTOR_URL }}|${{ github.actor }}>"
                       }
                     ]
                   },
@@ -137,6 +125,20 @@ runs:
                       "type": "mrkdwn",
                       "text": "${{ env.MESSAGE_OUTPUT }} "
                     }
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "image",
+                        "image_url": "https://slack.github.com/static/img/favicon-neutral.png",
+                        "alt_text": "GitHub"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ env.REPO_URL }}|${{ github.repository }}>"
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
The main text was missing from the payload: the API was generating warnings because of that:

```
[WARN]  web-api:WebClient:0 The top-level `text` argument is missing in the request payload for a chat.postMessage call - It's a best practice to always provide a `text` argument when posting a message. The `text` is used in places where the content cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
```

I just moved existing content around to make the message more compact and closer to other github skack notifications.

Here's a sample test notification:

![Screenshot from 2022-12-09 10-45-01](https://user-images.githubusercontent.com/608958/206673304-220d6e57-a843-463f-98de-bb0ff8b6f1c0.png)
