### PR TITLE
ACS-4245 Add 'global' option for configure-git-author action

### DIFF
--- a/.github/actions/configure-git-author/action.yml
+++ b/.github/actions/configure-git-author/action.yml
@@ -7,10 +7,18 @@ inputs:
   email:
     description: "Email"
     required: true
+  global:
+    description: "Global scope"
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
     - shell: bash
-      run: git config user.name ${{ inputs.username }}
-    - shell: bash
-      run: git config user.email ${{ inputs.email }}
+      run: |
+        GIT_GLOBAL_OPTION=''
+        if [ ${{ inputs.global }} = true ] ; then
+           GIT_GLOBAL_OPTION='--global'
+        fi
+        git config $GIT_GLOBAL_OPTION user.name ${{ inputs.username }}
+        git config $GIT_GLOBAL_OPTION user.email ${{ inputs.email }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -325,6 +325,7 @@ Configures the git username and email to associate commits with the provided ide
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
+          global: true
 ```
 
 ### get-branch-name


### PR DESCRIPTION
Added the `global` input for `configure-git-author` action to enable `--global` option if needed.