### PR TITLE
OPSEXP-1761: use per-LB sg annotation (-extra-security-groups)

### DIFF
--- a/.github/actions/dbp-charts/verify-helm/helm_install.sh
+++ b/.github/actions/dbp-charts/verify-helm/helm_install.sh
@@ -147,7 +147,7 @@ helm upgrade --install "${release_name_ingress}" --repo https://kubernetes.githu
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-ssl-cert"="${ACM_CERTIFICATE}" \
   --set controller.service.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="${HOST}" \
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-ssl-negotiation-policy"="ELBSecurityPolicy-TLS-1-2-2017-01" \
-  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-security-groups"="${AWS_SG}" \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-extra-security-groups"="${AWS_SG}" \
   --set controller.publishService.enabled=true \
   --set controller.admissionWebhooks.enabled=false \
   --set controller.ingressClassResource.enabled=false \


### PR DESCRIPTION
Ref: OPSEXP-1761

Tried it with maximum concurrency: https://github.com/Alfresco/acs-deployment/pull/836/checks

[OPSEXP-1761]: https://alfresco.atlassian.net/browse/OPSEXP-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ