### PR TITLE
[AAE-11861] add 'Create preview' feature

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'push' && ${{ contains(github.head_ref, 'preview') }}
+      if: github.event_name == 'push' && ${{ contains(github.event.pull_request.labels.*.name, 'Create preview') }}
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
@@ -127,7 +127,8 @@ runs:
           echo "command=verify" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' }}
+        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && \
+          contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
@@ -150,7 +151,8 @@ runs:
           echo "command=--push" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' }}
+        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && \
+          contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
     - name: Docker Build (and maybe Push)
       shell: bash

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -72,9 +72,17 @@ runs:
         ${{ inputs.verbose }} && NTP=''
         echo "result=--show-version --settings settings.xml $NTP" >> $GITHUB_OUTPUT
 
+    - name: Set is_preview env variable
+      id: set-is-preview-env-variable
+      env:
+        IS_PREVIEW: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') }}
+      shell: bash
+      run: |
+        echo "IS_PREVIEW=$IS_PREVIEW" >> $GITHUB_ENV
+
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
+      if: env.IS_PREVIEW
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
@@ -82,7 +90,7 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
+      if: github.event_name == 'push' || env.IS_PREVIEW
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
@@ -93,7 +101,7 @@ runs:
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
     - name: Set version env variable
-      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
+      if: github.event_name == 'push' || env.IS_PREVIEW
       env:
         VERSION: ${{ steps.update-pom-to-next-version.outputs.next-prerelease }}
       shell: bash
@@ -101,7 +109,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry
-      if: inputs.docker-username != '' && (github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
+      if: inputs.docker-username != '' && (github.event_name == 'push' || env.IS_PREVIEW)
       uses: docker/login-action@v2
       with:
         registry: docker.io
@@ -127,7 +135,7 @@ runs:
           echo "command=verify" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
+        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW }}
 
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
@@ -150,7 +158,7 @@ runs:
           echo "command=--push" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
+        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW }}
 
     - name: Docker Build (and maybe Push)
       shell: bash

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,6 +74,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
+      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -90,7 +90,7 @@ runs:
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
-        echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
+        echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,7 +74,6 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -86,7 +86,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: env.IS_PREVIEW
+      if: env.IS_PREVIEW == 'true'
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
@@ -94,7 +94,7 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push' || env.IS_PREVIEW
+      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-2-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
@@ -105,7 +105,7 @@ runs:
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
     - name: Set version env variable
-      if: github.event_name == 'push' || env.IS_PREVIEW
+      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
       env:
         VERSION: ${{ steps.update-pom-to-next-version.outputs.next-prerelease }}
       shell: bash
@@ -113,7 +113,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry
-      if: inputs.docker-username != '' && (github.event_name == 'push' || env.IS_PREVIEW)
+      if: inputs.docker-username != '' && (github.event_name == 'push' || env.IS_PREVIEW == 'true')
       uses: docker/login-action@v2
       with:
         registry: docker.io
@@ -139,7 +139,7 @@ runs:
           echo "command=verify" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW }}
+        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW == 'true' }}
 
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
@@ -162,7 +162,7 @@ runs:
           echo "command=--push" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW }}
+        DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW == 'true' }}
 
     - name: Docker Build (and maybe Push)
       shell: bash

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -77,7 +77,7 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        LABELS=${{ github.event.pull_request.labels.*.name }}
+        LABELS=${{ join(github.event.pull_request.labels.*.name, ', ') }}
         CONTAINS_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'Create preview') }}
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
         echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -85,7 +85,7 @@ runs:
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@v1.32.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.compute-maven-options.outputs.result }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -77,8 +77,6 @@ runs:
       if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
       shell: bash
       run: |
-        LABELS=${{ join(github.event.pull_request.labels.*.name, ', ') }}
-        CONTAINS_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'Create preview') }}
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
         echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
 

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
+      if: github.event_name == 'pull_request'
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -91,7 +91,7 @@ runs:
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || env.IS_PREVIEW
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-dev-jsokolowski
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-2-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.compute-maven-options.outputs.result }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -77,6 +77,8 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
+        LABELS=${{ github.event.pull_request.labels.*.name }}
+        CONTAINS_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'Create preview') }}
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
         echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
 

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -82,9 +82,15 @@ runs:
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
         echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
 
+    - name: Test1
+      id: test1
+      shell: bash
+      run: |
+        echo "test1"
+
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
@@ -94,6 +100,12 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
+    - name: Test2
+      id: test2
+      shell: bash
+      run: |
+        echo "test2"
+
     - name: Set version env variable
       if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
       env:
@@ -101,6 +113,12 @@ runs:
       shell: bash
       run: |
         echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Test3
+      id: test3
+      shell: bash
+      run: |
+        echo "test3"
 
     - name: Login to DockerHub Registry
       if: inputs.docker-username != '' && (github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
@@ -110,6 +128,12 @@ runs:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 
+    - name: Test4
+      id: test4
+      shell: bash
+      run: |
+        echo "test4"
+
     - name: Login to Quay.io Docker Registry
       if: inputs.quay-username != ''
       uses: docker/login-action@v2
@@ -117,6 +141,12 @@ runs:
         registry: quay.io
         username: ${{ inputs.quay-username }}
         password: ${{ inputs.quay-password }}
+
+    - name: Test5
+      id: test5
+      shell: bash
+      run: |
+        echo "test5"
 
     - name: Define Maven Command
       id: define_maven_command
@@ -131,6 +161,12 @@ runs:
       env:
         DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
+    - name: Test6
+      id: test6
+      shell: bash
+      run: |
+        echo "test6"
+
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
       run: mvn ${{ steps.define_maven_command.outputs.command }} ${{ env.MAVEN_CLI_OPTS}} ${{ inputs.extra-maven-opts }}
@@ -139,9 +175,21 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
+    - name: Test7
+      id: test7
+      shell: bash
+      run: |
+        echo "test7"
+
     - name: Echo Longest Tests run
       shell: bash
       run: find . -name TEST-*.xml -exec grep -h testcase {} \; | awk -F '"' '{printf("%s#%s() - %.3fms\n", $4, $2, $6); }' | sort -n -k 3 | tail -20
+
+    - name: Test8
+      id: test8
+      shell: bash
+      run: |
+        echo "test8"
 
     - name: Define Docker Push
       id: define_docker_push
@@ -153,6 +201,12 @@ runs:
         fi
       env:
         DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
+
+    - name: Test9
+      id: test9
+      shell: bash
+      run: |
+        echo "test9"
 
     - name: Docker Build (and maybe Push)
       shell: bash
@@ -168,12 +222,24 @@ runs:
         PUSH_OPTION: ${{ steps.define_docker_push.outputs.command }}
         TAG: ${{env.VERSION}}
 
+    - name: Test10
+      id: test10
+      shell: bash
+      run: |
+        echo "test10"
+
     - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.32.0
       if: github.event_name == 'push'
       with:
         username: ${{ inputs.git-username }}
         add-options: -u
         commit-message: "release $VERSION"
+
+    - name: Test11
+      id: test11
+      shell: bash
+      run: |
+        echo "test11"
 
     - name: Create and push tag
       if: github.event_name == 'push'

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -91,7 +91,7 @@ runs:
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || env.IS_PREVIEW
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@ref
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-2-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.compute-maven-options.outputs.result }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -80,12 +80,6 @@ runs:
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
         echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
 
-    - name: Test1
-      id: test1
-      shell: bash
-      run: |
-        echo "test1"
-
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
@@ -98,12 +92,6 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
-    - name: Test2
-      id: test2
-      shell: bash
-      run: |
-        echo "test2"
-
     - name: Set version env variable
       if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
       env:
@@ -111,12 +99,6 @@ runs:
       shell: bash
       run: |
         echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-    - name: Test3
-      id: test3
-      shell: bash
-      run: |
-        echo "test3"
 
     - name: Login to DockerHub Registry
       if: inputs.docker-username != '' && (github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
@@ -126,12 +108,6 @@ runs:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 
-    - name: Test4
-      id: test4
-      shell: bash
-      run: |
-        echo "test4"
-
     - name: Login to Quay.io Docker Registry
       if: inputs.quay-username != ''
       uses: docker/login-action@v2
@@ -139,12 +115,6 @@ runs:
         registry: quay.io
         username: ${{ inputs.quay-username }}
         password: ${{ inputs.quay-password }}
-
-    - name: Test5
-      id: test5
-      shell: bash
-      run: |
-        echo "test5"
 
     - name: Define Maven Command
       id: define_maven_command
@@ -159,12 +129,6 @@ runs:
       env:
         DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
-    - name: Test6
-      id: test6
-      shell: bash
-      run: |
-        echo "test6"
-
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
       run: mvn ${{ steps.define_maven_command.outputs.command }} ${{ env.MAVEN_CLI_OPTS}} ${{ inputs.extra-maven-opts }}
@@ -173,21 +137,9 @@ runs:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
-    - name: Test7
-      id: test7
-      shell: bash
-      run: |
-        echo "test7"
-
     - name: Echo Longest Tests run
       shell: bash
       run: find . -name TEST-*.xml -exec grep -h testcase {} \; | awk -F '"' '{printf("%s#%s() - %.3fms\n", $4, $2, $6); }' | sort -n -k 3 | tail -20
-
-    - name: Test8
-      id: test8
-      shell: bash
-      run: |
-        echo "test8"
 
     - name: Define Docker Push
       id: define_docker_push
@@ -199,12 +151,6 @@ runs:
         fi
       env:
         DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
-
-    - name: Test9
-      id: test9
-      shell: bash
-      run: |
-        echo "test9"
 
     - name: Docker Build (and maybe Push)
       shell: bash
@@ -220,24 +166,12 @@ runs:
         PUSH_OPTION: ${{ steps.define_docker_push.outputs.command }}
         TAG: ${{env.VERSION}}
 
-    - name: Test10
-      id: test10
-      shell: bash
-      run: |
-        echo "test10"
-
     - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.32.0
       if: github.event_name == 'push'
       with:
         username: ${{ inputs.git-username }}
         add-options: -u
         commit-message: "release $VERSION"
-
-    - name: Test11
-      id: test11
-      shell: bash
-      run: |
-        echo "test11"
 
     - name: Create and push tag
       if: github.event_name == 'push'

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
       shell: bash
       run: |
         LABELS=${{ join(github.event.pull_request.labels.*.name, ', ') }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -91,7 +91,7 @@ runs:
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || env.IS_PREVIEW
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-2-dev-jsokolowski
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@ref
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.compute-maven-options.outputs.result }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
+      if: github.event_name == 'push'
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@AAE-11861-preview-version-dev-jsokolowski
       with:
         property-to-update: ${{ inputs.property-to-update }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -82,8 +82,7 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && \
-        contains(github.event.pull_request.labels.*.name, 'Create preview') )
+      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@v1.32.0
       with:
         property-to-update: ${{ inputs.property-to-update }}
@@ -94,8 +93,7 @@ runs:
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
     - name: Set version env variable
-      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && \
-        contains(github.event.pull_request.labels.*.name, 'Create preview') )
+      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') )
       env:
         VERSION: ${{ steps.update-pom-to-next-version.outputs.next-prerelease }}
       shell: bash
@@ -103,8 +101,7 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry
-      if: inputs.docker-username != '' && (github.event_name == 'push' || \
-        ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
+      if: inputs.docker-username != '' && (github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
       uses: docker/login-action@v2
       with:
         registry: docker.io
@@ -130,8 +127,7 @@ runs:
           echo "command=verify" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && \
-          contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
+        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
@@ -154,8 +150,7 @@ runs:
           echo "command=--push" >> $GITHUB_OUTPUT
         fi
       env:
-        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && \
-          contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
+        DO_PUSH: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) }}
 
     - name: Docker Build (and maybe Push)
       shell: bash

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -72,6 +72,14 @@ runs:
         ${{ inputs.verbose }} && NTP=''
         echo "result=--show-version --settings settings.xml $NTP" >> $GITHUB_OUTPUT
 
+    - name: Set preview version
+      id: set-preview-version
+      if: github.event_name == 'push' && ${{ contains(github.head_ref, 'preview') }}
+      shell: bash
+      run: |
+        GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
+        echo "preview-version=0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT" >> $GITHUB_OUTPUT
+
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push'
@@ -79,6 +87,7 @@ runs:
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.compute-maven-options.outputs.result }}
+        version: ${{ steps.set-preview-version.outputs.preview-version }}
       env:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Set preview version
       id: set-preview-version
-      if: github.event_name == 'push' && ${{ contains(github.event.pull_request.labels.*.name, 'Create preview') }}
+      if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview')
       shell: bash
       run: |
         GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
@@ -82,7 +82,8 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && \
+        contains(github.event.pull_request.labels.*.name, 'Create preview') )
       uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@v1.32.0
       with:
         property-to-update: ${{ inputs.property-to-update }}
@@ -93,7 +94,8 @@ runs:
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
 
     - name: Set version env variable
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || ( github.event_name == 'pull_request' && \
+        contains(github.event.pull_request.labels.*.name, 'Create preview') )
       env:
         VERSION: ${{ steps.update-pom-to-next-version.outputs.next-prerelease }}
       shell: bash
@@ -101,7 +103,8 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry
-      if: github.event_name == 'push' && inputs.docker-username != ''
+      if: inputs.docker-username != '' && (github.event_name == 'push' || \
+        ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') ) )
       uses: docker/login-action@v2
       with:
         registry: docker.io

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: Whether additional logs should be displayed (maven download logs for instance)
     required: false
     default: 'false'
+  preview-label:
+    description: The label name for creating a preview version
+    required: false
+    default: 'preview'
 
 outputs:
   version:
@@ -75,7 +79,7 @@ runs:
     - name: Set is_preview env variable
       id: set-is-preview-env-variable
       env:
-        IS_PREVIEW: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Create preview') }}
+        IS_PREVIEW: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, inputs.preview-label) }}
       shell: bash
       run: |
         echo "IS_PREVIEW=$IS_PREVIEW" >> $GITHUB_ENV

--- a/.github/actions/maven-update-pom-version/action.yml
+++ b/.github/actions/maven-update-pom-version/action.yml
@@ -13,10 +13,6 @@ inputs:
   repository-directory:
     description: git repository holding the code
     required: false
-outputs:
-  next-prerelease:
-    description: "Next prerelease"
-    value: ${{ steps.resolve-version.outputs.version }}
 runs:
   using: composite
   steps:

--- a/.github/actions/maven-update-pom-version/action.yml
+++ b/.github/actions/maven-update-pom-version/action.yml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   next-prerelease:
     description: "Next prerelease"
-    value: ${{ steps.next-prerelease-resolver.outputs.next-prerelease }}
+    value: ${{ steps.resolve-version.outputs.version }}
 runs:
   using: composite
   steps:

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Parse next version from POM
       id: parse-next-final-version
-      if: inputs.version != ''
+      if: inputs.version == ''
       shell: bash
       run: |
         NEXT_VERSION=$(yq -p=xml e '.project.version' pom.xml | grep -o "[0-9]*\.[0-9]*.[0-9]*")
@@ -32,7 +32,7 @@ runs:
 
     - id: next-prerelease-resolver
       name: Calculate next internal release
-      if: inputs.version != ''
+      if: inputs.version == ''
       uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.32.0
       with:
         next-version: ${{ steps.parse-next-final-version.outputs.result }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: Update pom files to the new version
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@AAE-11861-preview-version-dev-jsokolowski
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@AAE-11861-preview-version-2-dev-jsokolowski
       with:
         version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: Update pom files to the new version
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@AAE-11861-preview-version-2-dev-jsokolowski
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@ref
       with:
         version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: Update pom files to the new version
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@ref
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@AAE-11861-preview-version-2-dev-jsokolowski
       with:
         version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -38,7 +38,7 @@ runs:
         next-version: ${{ steps.parse-next-final-version.outputs.result }}
         prerelease-type: ${{ inputs.prerelease-type }}
 
-    - id: reolve-version
+    - id: resolve-version
       name: Resolve version
       shell: bash
       run: |
@@ -52,6 +52,6 @@ runs:
     - name: Update pom files to the new version
       uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@v1.32.0
       with:
-        version: ${{ steps.reolve-version.outputs.version }}
+        version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}
         property-to-update: ${{ inputs.property-to-update }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -11,6 +11,9 @@ inputs:
   property-to-update:
     description: property to update in addition to the version of the pom file
     required: false
+  version:
+    description: custom version to be set
+    required: false
 outputs:
   next-prerelease:
     description: "Next prerelease"
@@ -20,6 +23,7 @@ runs:
   steps:
     - name: Parse next version from POM
       id: parse-next-final-version
+      if: inputs.version != ''
       shell: bash
       run: |
         NEXT_VERSION=$(yq -p=xml e '.project.version' pom.xml | grep -o "[0-9]*\.[0-9]*.[0-9]*")
@@ -28,14 +32,26 @@ runs:
 
     - id: next-prerelease-resolver
       name: Calculate next internal release
+      if: inputs.version != ''
       uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.32.0
       with:
         next-version: ${{ steps.parse-next-final-version.outputs.result }}
         prerelease-type: ${{ inputs.prerelease-type }}
 
+    - id: reolve-version
+      name: Resolve version
+      shell: bash
+      run: |
+        if [ ${{ inputs.version }} != '' ]
+        then
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+        else
+          echo "version=${{ steps.next-prerelease-resolver.outputs.next-prerelease }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Update pom files to the new version
       uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@v1.32.0
       with:
-        version: ${{ steps.next-prerelease-resolver.outputs.next-prerelease }}
+        version: ${{ steps.reolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}
         property-to-update: ${{ inputs.property-to-update }}

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -17,7 +17,7 @@ inputs:
 outputs:
   next-prerelease:
     description: "Next prerelease"
-    value: ${{ steps.next-prerelease-resolver.outputs.next-prerelease }}
+    value: ${{ steps.resolve-version.outputs.version }}
 runs:
   using: composite
   steps:
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: Update pom files to the new version
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@v1.32.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@AAE-11861-preview-version-dev-jsokolowski
       with:
         version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -598,6 +598,12 @@ Check out, builds a maven project and docker images, generating a new alpha vers
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
 ```
 
+#### Preview option for maven-build-and-tag
+
+There is a possibility to publish snapshot maven artifacts and docker images from an open PR. 
+In order to use it specify `preview-label` input (or use default `preview`). Create a PR with the `preview-label` label.
+The created artifacts will be tagged as `0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT`.
+
 ### maven-deploy-file
 
 Upload one or more files to a maven server, without requiring the presence of a

--- a/docs/README.md
+++ b/docs/README.md
@@ -600,7 +600,7 @@ Check out, builds a maven project and docker images, generating a new alpha vers
 
 #### Preview option for maven-build-and-tag
 
-There is a possibility to publish snapshot maven artifacts and docker images from an open PR. 
+There is a possibility to publish snapshot maven artifacts and docker images from an open PR.
 In order to use it specify `preview-label` input (or use default `preview`). Create a PR with the `preview-label` label.
 The created artifacts will be tagged as `0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -602,7 +602,7 @@ Check out, builds a maven project and docker images, generating a new alpha vers
 
 There is a possibility to publish snapshot maven artifacts and docker images from an open PR.
 In order to use it specify `preview-label` input (or use default `preview`). Create a PR with the `preview-label` label.
-The created artifacts will be tagged as `0.0.1-$GITHUB_PR_NUMBER-$GITHUB_RUN_NUMBER-SNAPSHOT`.
+The created maven artifacts and docker images will be tagged as `0.0.1-$GITHUB_PR_NUMBER-SNAPSHOT`.
 
 ### maven-deploy-file
 


### PR DESCRIPTION
When a PR is created with `preview` label, the build creates and publishes maven versions and docker images for the project with a snapshot tag `0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT`. Tested e.g. on https://github.com/Alfresco/alfresco-deployment-service/pull/996