### PR TITLE
ACS-3844 Contribute get-build-info to alfresco-build-tools

### DIFF
--- a/.github/actions/get-build-info/action.yml
+++ b/.github/actions/get-build-info/action.yml
@@ -1,0 +1,19 @@
+name: "Get build info"
+description: "Get build-related info from GitHub and load it as generically named variables into the runner env"
+runs:
+  using: composite
+  steps:
+    - uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v1.29.0
+    - name: "Get build info"
+      run: |
+        [[ $GITHUB_EVENT_NAME == "pull_request" ]] && IS_PULL_REQUEST="true" || IS_PULL_REQUEST="false"
+        echo "PULL_REQUEST=$IS_PULL_REQUEST" >> "$GITHUB_ENV"
+        echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER" >> "$GITHUB_ENV"
+        echo "ATTEMPT_NUMBER=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
+        echo "JOB_NAME=$GITHUB_JOB" >> "$GITHUB_ENV"
+
+        echo "Pull Request: '$IS_PULL_REQUEST'"
+        echo "Build Number: '$GITHUB_RUN_NUMBER'"
+        echo "Attempt Number: '$GITHUB_RUN_ATTEMPT'"
+        echo "Job Name: '$GITHUB_JOB'"
+      shell: bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Here follows the list of GitHub Actions topics available in the current document
     - [automate-propagation](#automate-propagation)
     - [configure-git-author](#configure-git-author)
     - [get-branch-name](#get-branch-name)
+    - [get-build-info](#get-build-info)
     - [git-check-existing-tag](#git-check-existing-tag)
     - [get-commit-message](#get-commit-message)
     - [git-commit-changes](#git-commit-changes)
@@ -336,6 +337,14 @@ Loads the name of the branch on which the action was called into `BRANCH_NAME` e
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@ref
+```
+
+### get-build-info
+
+[get-build-info](../.github/actions/get-build-info/action.yml) loads build-related info into the runner env, in the form of generically named variables that are not necessarily specific to GitHub.
+
+```yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@ref
 ```
 
 ### git-check-existing-tag


### PR DESCRIPTION
Contributing the `get-build-info` action to load generically named env vars with build-related information. This is particularly useful for repositories that contain scripts relying on Travis/GitHub specific env variables and should rather rely on more abstract env variables to mitigate migration impacts in the future.