### PR TITLE
ACS-3750 Set default veracode-fails-build to 'true'

### DIFF
--- a/.github/actions/veracode/action.yml
+++ b/.github/actions/veracode/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   veracode-fails-build:
     description: "Determine if the veracode scan result should fail the build"
-    default: "false"
+    default: "true"
     required: false
 runs:
   using: "composite"

--- a/.github/actions/veracode/action.yml
+++ b/.github/actions/veracode/action.yml
@@ -4,10 +4,6 @@ inputs:
   srcclr-api-token:
     description: "Agent API Token"
     required: true
-  veracode-fails-build:
-    description: "Determine if the veracode scan result should fail the build"
-    default: "true"
-    required: false
 runs:
   using: "composite"
   steps:
@@ -16,4 +12,3 @@ runs:
       shell: bash
       env:
         SRCCLR_API_TOKEN: ${{ inputs.srcclr-api-token }}
-        VERACODE_FAILS_BUILD: ${{ inputs.veracode-fails-build }}

--- a/.github/actions/veracode/source_clear.sh
+++ b/.github/actions/veracode/source_clear.sh
@@ -12,10 +12,6 @@ mvn -B -q clean install \
 
 SUCCESS=$?   # this will read exit code of the previous command
 
-if [ -z "$VERACODE_FAILS_BUILD" ] || [ "$VERACODE_FAILS_BUILD" = false ] ; then
-    SUCCESS=0
-fi
-
 grep -e 'Full Report Details' -e 'Failed' scan.log
 
 set +vex

--- a/docs/README.md
+++ b/docs/README.md
@@ -1060,9 +1060,9 @@ Runs Veracode Source Clear Scan
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@ref
+        #continue-on-error: true # uncomment this line to prevent the Veracode scan step from failing the whole build
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
-          veracode-fails-build: "false" # default is "true"
 ```
 
 ## Reusable workflows provided by us

--- a/docs/README.md
+++ b/docs/README.md
@@ -1062,7 +1062,7 @@ Runs Veracode Source Clear Scan
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@ref
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
-          veracode-fails-build: "false"
+          veracode-fails-build: "false" # default is "true"
 ```
 
 ## Reusable workflows provided by us


### PR DESCRIPTION
I think it'd be safer to err on the side of caution and cause the builds to fail by default if the Veracode scan reports critical vulnerabilities or fails completely.

Also, given that the default value is to ignore failures, people trying to adopt the Veracode action often don't even realize that they're missing critical components to make the Veracode action work _(e.g.: the `SRCCLR_API_TOKEN` secret may be missing in the repository configuration, but it won't be very evident as the job goes green anyways)_.

It would be great to release this change before we start introducing the Veracode action into more repositories, so it won't be as impacting.