### PR TITLE
ACS-4456 Add reusable workflow for basic Maven build and release

### DIFF
--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -87,6 +87,5 @@ jobs:
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
         run: mvn -B -V install -DskipTests
-       Temporarily halt release for testing purposes
       - name: "Release"
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -18,6 +18,11 @@ on:
         type: string
         required: false
         default: '' # defaults to github.event.repository.default_branch
+      release-args:
+        description: additional Maven release arguments
+        type: string
+        required: false
+        default: ''
     secrets:
         BOT_GITHUB_USERNAME:
           required: true
@@ -88,4 +93,4 @@ jobs:
       - name: "Build"
         run: mvn -B -V install -DskipTests
       - name: "Release"
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-arguments }}" release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      build-args:
+        description: additional Maven build arguments
+        type: string
+        required: false
+        default: ''
       auto-release:
         description: release automatically or only when the [release] commit trigger is present
         type: boolean
@@ -49,10 +54,10 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.33.0
       - name: "Build"
         if: ${{ inputs.skip-tests }}
-        run: mvn -B -V install -DskipTests
+        run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Build and Test"
         if: ${{ !inputs.skip-tests }}
-        run: mvn -B -V install
+        run: mvn -B -V install ${{ inputs.build-args }}
 
   compute_release_conditions:
     name: "Compute Release conditions"
@@ -91,6 +96,6 @@ jobs:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
-        run: mvn -B -V install -DskipTests
+        run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Release"
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -15,7 +15,7 @@ env:
   MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
 
 jobs:
-  test:
+  build:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +31,7 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    needs: test
+    needs: build
     if: >
       github.ref_name == 'master' && github.event_name != 'pull_request' &&
        !contains(github.event.head_commit.message, '[no-release]')

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -93,4 +93,4 @@ jobs:
       - name: "Build"
         run: mvn -B -V install -DskipTests
       - name: "Release"
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-arguments }}" release:clean release:prepare release:perform
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
+      - name: "Build"
+        if: ${{ inputs.skip-tests }}
+        run: mvn -B -V install -DskipTests
       - name: "Build and Test"
         if: ${{ !inputs.skip-tests }}
         run: mvn -B -V install
-      - name: "Build and Test"
-        if: ${{ inputs.skip-tests }}
-        run: mvn -B -V install -DskipTests
 
   release:
     name: "Release"

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -1,0 +1,50 @@
+name: Build and Release Maven project
+
+on:
+  workflow_call:
+    inputs:
+      skip-tests:
+        description: skips the tests during the Build phase if set to 'true'
+        type: boolean
+        required: false
+        default: false
+
+env:
+  GIT_PASSWORD: ${{ secrets.BOT_GITHUB_TOKEN }}
+  MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+  MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+
+jobs:
+  test:
+    name: "Build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
+      - name: "Build and Test"
+        if: ${{ !inputs.skip-tests }}
+        run: mvn -B -V install
+      - name: "Build and Test"
+        if: ${{ inputs.skip-tests }}
+        run: mvn -B -V install -DskipTests
+
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    needs: test
+    if: >
+      github.ref_name == 'master' && github.event_name != 'pull_request' &&
+       !contains(github.event.head_commit.message, '[no-release]')
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.32.0
+        with:
+          username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          email: ${{ secrets.BOT_GITHUB_EMAIL }}
+      - name: "Install settings.xml"
+        run: cp .github/.ci.settings.xml $HOME/.m2/settings.xml
+      - name: "Build"
+        run: mvn -B -V install -DskipTests
+      - name: "Release"
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -8,6 +8,16 @@ on:
         type: boolean
         required: false
         default: false
+      auto-release:
+        description: release automatically or only when the [release] commit trigger is present
+        type: boolean
+        required: false
+        default: true
+      release-branches:
+        description: regex defining branches that are valid for the release process
+        type: string
+        required: false
+        default: '' # defaults to github.event.repository.default_branch
     secrets:
         BOT_GITHUB_USERNAME:
           required: true
@@ -39,13 +49,35 @@ jobs:
         if: ${{ !inputs.skip-tests }}
         run: mvn -B -V install
 
+  compute_release_conditions:
+    name: "Compute Release conditions"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Compute Release conditions
+        id: compute
+        run: |
+          SHOULD_RELEASE=false
+
+          RELEASE_BRANCHES="${{ inputs.release-branches }}"
+          if [[ -z "$RELEASE_BRANCHES" ]]; then
+            RELEASE_BRANCHES="^${{ github.event.repository.default_branch }}$"
+          fi
+
+          if [[ ! "${{ github.event.head_commit.message }}" =~ \[no-release\] ]] && [[ "${{ github.ref_name }}" =~ $RELEASE_BRANCHES ]]; then
+            if [[ "${{ inputs.auto-release }}" == "true" ]] || [[  "${{ github.event.head_commit.message }}" =~ \[release\] ]]; then
+              SHOULD_RELEASE=true
+            fi
+          fi
+          echo "should_release=${SHOULD_RELEASE}" >> $GITHUB_OUTPUT
+    outputs:
+      should_release: ${{ steps.compute.outputs.should_release }}
+
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    needs: build
-    if: >
-      github.ref_name == 'master' && github.event_name != 'pull_request' &&
-       !contains(github.event.head_commit.message, '[no-release]')
+    needs: compute_release_conditions
+    if: needs.compute_release_conditions.outputs.should_release == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.33.0
@@ -55,5 +87,6 @@ jobs:
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
         run: mvn -B -V install -DskipTests
-      - name: "Release"
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+      # Temporarily halt release for testing purposes
+      #- name: "Release"
+      #  run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -8,11 +8,18 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+        BOT_GITHUB_TOKEN:
+          required: true
+        NEXUS_USERNAME:
+          required: true
+        NEXUS_PASSWORD:
+          required: true
 
 env:
   GIT_PASSWORD: ${{ secrets.BOT_GITHUB_TOKEN }}
-  MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+  MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
 jobs:
   build:

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
     secrets:
+        BOT_GITHUB_USERNAME:
+          required: true
+        BOT_GITHUB_EMAIL:
+          required: true
         BOT_GITHUB_TOKEN:
           required: true
         NEXUS_USERNAME:
@@ -27,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.33.0
       - name: "Build"
         if: ${{ inputs.skip-tests }}
         run: mvn -B -V install -DskipTests
@@ -44,13 +48,11 @@ jobs:
        !contains(github.event.head_commit.message, '[no-release]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.33.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.33.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
-      - name: "Install settings.xml"
-        run: cp .github/.ci.settings.xml $HOME/.m2/settings.xml
       - name: "Build"
         run: mvn -B -V install -DskipTests
       - name: "Release"

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -87,6 +87,6 @@ jobs:
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
         run: mvn -B -V install -DskipTests
-      # Temporarily halt release for testing purposes
-      #- name: "Release"
-      #  run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+       Temporarily halt release for testing purposes
+      - name: "Release"
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform


### PR DESCRIPTION
Adding a reusable workflow to match the most common Travis workflow we have at the moment, which seems to simply be build _(sometimes with tests)_ -> release.

Example of usage: https://github.com/Alfresco/alfresco-tas-ftp-test/actions/runs/4016617042

**Note:** this is a work in progress, and will be merged only once most if not all repositories that should use such a basic workflow have been tested and therefore the workflow has become at least abstract enough to be utilized properly within all ACS repositories with similar, simple workflows.