### PR TITLE
ACS-4455 Install custom settings.xml as part of setup-java-build

### DIFF
--- a/.github/actions/setup-java-build/action.yml
+++ b/.github/actions/setup-java-build/action.yml
@@ -25,7 +25,9 @@ runs:
           ${{ runner.os }}-maven-
     - name: "Install ${{ inputs.maven-settings }}"
       shell: bash
-      run: "cp ${{ inputs.maven-settings }} $HOME/.m2/settings.xml || :"
+      run: >
+        mkdir $HOME/.m2
+        cp ${{ inputs.maven-settings }} $HOME/.m2/settings.xml || true
     - name: "Set up Java"
       uses: actions/setup-java@v3
       with:

--- a/.github/actions/setup-java-build/action.yml
+++ b/.github/actions/setup-java-build/action.yml
@@ -25,7 +25,7 @@ runs:
           ${{ runner.os }}-maven-
     - name: "Install ${{ inputs.maven-settings }}"
       shell: bash
-      run: >
+      run: |
         mkdir -p $HOME/.m2
         cp ${{ inputs.maven-settings }} $HOME/.m2/settings.xml || true
     - name: "Set up Java"

--- a/.github/actions/setup-java-build/action.yml
+++ b/.github/actions/setup-java-build/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: the desired Java distribution
     default: "temurin"
     required: false
+  maven-settings:
+    description: the location of the custom Maven settings.xml file to install
+    default: ".ci.settings.xml"
+    required: false
 runs:
   using: composite
   steps:
@@ -19,6 +23,9 @@ runs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    - name: "Install ${{ inputs.maven-settings }}"
+      shell: bash
+      run: "cp ${{ inputs.maven-settings }} $HOME/.m2/settings.xml || :"
     - name: "Set up Java"
       uses: actions/setup-java@v3
       with:

--- a/.github/actions/setup-java-build/action.yml
+++ b/.github/actions/setup-java-build/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: "Install ${{ inputs.maven-settings }}"
       shell: bash
       run: >
-        mkdir $HOME/.m2
+        mkdir -p $HOME/.m2
         cp ${{ inputs.maven-settings }} $HOME/.m2/settings.xml || true
     - name: "Set up Java"
       uses: actions/setup-java@v3

--- a/docs/README.md
+++ b/docs/README.md
@@ -1001,6 +1001,7 @@ See [setup-helm-docs](../.github/actions/setup-helm-docs/action.yml) for a usage
         with:
           java-version: "17" # optional
           java-distribution: "temurin" # optional
+          maven-settings: ".ci.settings.xml" # optional
 ```
 
 ### setup-kind


### PR DESCRIPTION
Installs a custom `settings.xml` file in the Maven home directory. Does not fail in case the file is not found, as not all repositories may need to install the custom file.

**Sample run**: https://github.com/Alfresco/alfresco-enterprise-repo/pull/1221