### PR TITLE
ACS-4456 Fix private repository releases with reusable workflow

### DIFF
--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -41,6 +41,7 @@ on:
           required: true
 
 env:
+  GIT_USERNAME: ${{ secrets.BOT_GITHUB_USERNAME }}
   GIT_PASSWORD: ${{ secrets.BOT_GITHUB_TOKEN }}
   MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
   MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
@@ -98,4 +99,4 @@ jobs:
       - name: "Build"
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Release"
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform


### PR DESCRIPTION
Private repository releases with the `build-and-release-maven.yml` workflow fail due to missing username.