### PR TITLE
ACS-4500 Fix skip tests in reusable workflow

### DIFF
--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.34.2
+      - name: "Echo skip-tests"
+        run: echo ${{ input.skip-tests }}
       - name: "Build"
         if: ${{ inputs.skip-tests == 'true' }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -54,10 +54,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.34.2
       - name: "Build"
-        if: ${{ inputs.skip-tests }}
+        if: ${{ inputs.skip-tests == 'true' }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Build and Test"
-        if: ${{ !inputs.skip-tests }}
+        if: ${{ inputs.skip-tests == 'false' }}
         run: mvn -B -V install ${{ inputs.build-args }}
 
   compute_release_conditions:

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ inputs.skip-tests == 'true' }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Build and Test"
-        if: ${{ inputs.skip-tests == 'false' }}
+        if: ${{ inputs.skip-tests != 'true' }}
         run: mvn -B -V install ${{ inputs.build-args }}
 
   compute_release_conditions:

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -54,7 +54,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.34.2
       - name: "Echo skip-tests"
-        run: echo ${{ input.skip-tests }}
+        run: >
+          echo ${{ inputs.skip-tests }}
       - name: "Build"
         if: ${{ inputs.skip-tests == 'true' }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}


### PR DESCRIPTION
Testing skip tests functionality in reusable workflow revealed that it doesn't work as intended. Possibly related to https://github.com/actions/runner/issues/1483.