### PR TITLE
OPSEXP-1853: add an helm plugin action

### DIFF
--- a/.github/actions/helm-plugin/action.yml
+++ b/.github/actions/helm-plugin/action.yml
@@ -1,0 +1,22 @@
+---
+name: Helm Plugin install
+description: >
+  Install an helm plugin from provided url
+inputs:
+  plugin_url:
+    description: URL where to get the plugin from
+    required: true
+  plugin_version:
+    description: version of the helm-unittest plugin to install
+    required: false
+    default: latest
+runs:
+  using: composite
+  steps:
+    - name: Install Helm plugin ${{ inputs.plugin_url }}
+      shell: bash
+      run: |
+        set -e
+        [ ${{ inputs.plugin_version }} != 'latest' ] && \
+        VER="--version ${{ inputs.plugin_version }}"
+        helm plugin install ${{ inputs.plugin_url }} $VER

--- a/.github/actions/helm-unit-tests/action.yml
+++ b/.github/actions/helm-unit-tests/action.yml
@@ -25,6 +25,7 @@ runs:
       if: ${{ inputs.chart-type }} != 'library'
       run: |
         set -e
+        echo "::warning title=DEPRECATED ACTION::helm-unittest action is deprecated, use Alfresco/alfresco-build-tools/.github/actions/helm-plugin instead."
         if [ -d tests ]; then echo "${{ inputs.chart-dir }}: Unit tests"
           helm plugin install https://github.com/vbehar/helm3-unittest --version ${{ inputs.plugin_version }}
           helm dep up

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Here follows the list of GitHub Actions topics available in the current document
     - [helm-publish-chart](#helm-publish-chart)
     - [helm-release-and-publish](#helm-release-and-publish)
     - [helm-template-yamllint](#helm-template-yamllint)
+    - [helm-plugin](#helm-plugin)
     - [helm-unit-tests](#helm-unit-tests)
     - [helm-update-chart-version](#helm-update-chart-version)
     - [jx-updatebot-pr](#jx-updatebot-pr)
@@ -502,6 +503,20 @@ configuration files that should be suitable for most use cases.
           helm-options: --values tests/values/test_values.yaml --set persistence.enabled=false # to handle mandatory values or test different rendering
           yamllint-config-path: ./.yamllint.yaml # alternative path to yamllint config to override the default one
 ```
+
+### helm-plugin
+
+Install requested Helm plugin
+
+```yaml
+     - uses: >-
+         Alfresco/alfresco-build-tools/.github/actions/helm-plugin@ref
+       with:
+         plugin_url: https://domain/path/to/
+         plugin_version: v1.0.0
+```
+
+`plugin_version` can be skipped so the latest release of the plugin will be installed
 
 ### helm-unit-tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -530,6 +530,9 @@ Looks for Helm unit tests written using [helm3-unittest](https://github.com/vbeh
          chart-type: application
 ```
 
+> This plugin is unmaintained and that action will be deprecated. Please use the `helm-plugin` instead
+> together with an additional `run` step to fire up the plugin.
+
 ### helm-update-chart-version
 
 Updates `version` attribute inside `Chart.yaml` file:


### PR DESCRIPTION
Ref: OPSEXP-1853

The helm3-unittest plugin we introduced is now superseeded by the helm-unitest one. Instead of introducing a feature flip to choose which unittest plugin I prefer introducing a generic plugin install action and deprecate the old one.