### PR TITLE
AFI-1520:Externalize required parameters for build in build-and-relea…

### DIFF
--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -7,10 +7,12 @@ on:
         description: the desired Java version
         type: string
         required: false
+        default: "17"
       java-distribution:
         description: the desired Java distribution
         type: string
         required: false
+        default: "temurin"
       skip-tests:
         description: skips the tests during the Build phase if set to 'true'
         type: boolean
@@ -36,12 +38,8 @@ on:
         type: string
         required: false
         default: ''
-      release-version:
-        description: the name of the version to be released
-        type: string
-        required: false
-      next-dev-version:
-        description: the name of the version to be set as next development version
+      extra-maven-opts:
+        description: additional Maven build options
         type: string
         required: false
 
@@ -67,15 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Setup Java Build with specific configuration"
-        if: inputs.java-version != '' && inputs.java-distribution != ''
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
         with:
           java-version: ${{ inputs.java-version}}
           java-distribution: ${{ inputs.java-distribution}}
-      - name: "Setup Java Build with default configuration"
-        if: inputs.java-version == '' || inputs.java-distribution == ''
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - name: "Build"
         if: ${{ inputs.skip-tests }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
@@ -114,24 +107,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup Java Build with specific configuration"
-        if: inputs.java-version && inputs.java-distribution
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
         with:
-          java-version: ${{ inputs.java-version}}
-          java-distribution: ${{ inputs.java-distribution}}
-      - name: "Setup Java Build with default configuration"
-        if: inputs.java-version == '' || inputs.java-distribution == ''
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+          java-version: ${{ inputs.java-version }}
+          java-distribution: ${{ inputs.java-distribution }}
       - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.36.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
-      - name: "Release with specific version"
-        if: inputs.release-version && inputs.next-dev-version
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" -DreleaseVersion="${{ inputs.release-version }}" -DdevelopmentVersion="${{ inputs.next-dev-version }}" release:clean release:prepare release:perform
-      - name: "Release with default version"
-        if: inputs.release-version == '' || inputs.next-dev-version == ''
-        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform
+      - name: "Release"
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" ${{ inputs.extra-maven-opts }} release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -119,3 +119,4 @@ jobs:
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Release"
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" ${{ inputs.extra-maven-opts }} release:clean release:prepare release:perform
+        

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -135,4 +135,3 @@ jobs:
       - name: "Release with default version" 
         if: inputs.release-version == '' || inputs.next-dev-version == ''
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform
-        

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -132,6 +132,6 @@ jobs:
       - name: "Release with specific version"
         if: inputs.release-version && inputs.next-dev-version
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" -DreleaseVersion="${{ inputs.release-version }}" -DdevelopmentVersion="${{ inputs.next-dev-version }}" release:clean release:prepare release:perform
-      - name: "Release with default version" 
+      - name: "Release with default version"
         if: inputs.release-version == '' || inputs.next-dev-version == ''
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -119,4 +119,3 @@ jobs:
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Release"
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" ${{ inputs.extra-maven-opts }} release:clean release:prepare release:perform
-        

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -3,6 +3,14 @@ name: Build and Release Maven project
 on:
   workflow_call:
     inputs:
+      java-version:
+        description: the desired Java version
+        type: string
+        required: false
+      java-distribution:
+        description: the desired Java distribution
+        type: string
+        required: false
       skip-tests:
         description: skips the tests during the Build phase if set to 'true'
         type: boolean
@@ -28,6 +36,15 @@ on:
         type: string
         required: false
         default: ''
+      release-version:
+        description: the name of the version to be released
+        type: string
+        required: false
+      next-dev-version:
+        description: the name of the version to be set as next development version
+        type: string
+        required: false
+
     secrets:
         BOT_GITHUB_USERNAME:
           required: false
@@ -50,7 +67,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - name: "Setup Java Build with specific configuration"
+        if: inputs.java-version != '' && inputs.java-distribution != ''
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+        with:
+          java-version: ${{ inputs.java-version}}
+          java-distribution: ${{ inputs.java-distribution}}
+      - name: "Setup Java Build with default configuration"
+        if: inputs.java-version == '' || inputs.java-distribution == ''
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - name: "Build"
         if: ${{ inputs.skip-tests }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
@@ -67,12 +92,10 @@ jobs:
         id: compute
         run: |
           SHOULD_RELEASE=false
-
           RELEASE_BRANCHES="${{ inputs.release-branches }}"
           if [[ -z "$RELEASE_BRANCHES" ]]; then
             RELEASE_BRANCHES="^${{ github.event.repository.default_branch }}$"
           fi
-
           if [[ ! "${{ github.event.head_commit.message }}" =~ \[no-release\] ]] && [[ "${{ github.ref_name }}" =~ $RELEASE_BRANCHES ]]; then
             if [[ "${{ inputs.auto-release }}" == "true" ]] || [[  "${{ github.event.head_commit.message }}" =~ \[release\] ]]; then
               SHOULD_RELEASE=true
@@ -91,12 +114,24 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - name: "Setup Java Build with specific configuration"
+        if: inputs.java-version && inputs.java-distribution
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+        with:
+          java-version: ${{ inputs.java-version}}
+          java-distribution: ${{ inputs.java-distribution}}
+      - name: "Setup Java Build with default configuration"
+        if: inputs.java-version == '' || inputs.java-distribution == ''
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.36.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
-      - name: "Release"
+      - name: "Release with specific version"
+        if: inputs.release-version && inputs.next-dev-version
+        run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" -DreleaseVersion="${{ inputs.release-version }}" -DdevelopmentVersion="${{ inputs.next-dev-version }}" release:clean release:prepare release:perform
+      - name: "Release with default version" 
+        if: inputs.release-version == '' || inputs.next-dev-version == ''
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -67,8 +67,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
         with:
-          java-version: ${{ inputs.java-version}}
-          java-distribution: ${{ inputs.java-distribution}}
+          java-version: ${{ inputs.java-version }}
+          java-distribution: ${{ inputs.java-distribution }}
       - name: "Build"
         if: ${{ inputs.skip-tests }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -135,3 +135,4 @@ jobs:
       - name: "Release with default version" 
         if: inputs.release-version == '' || inputs.next-dev-version == ''
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" release:clean release:prepare release:perform
+        


### PR DESCRIPTION
We need to externalize the following parameters for building the sap-connector projects,
1. java-version
2. java-distribution
3. release-version
4. next-dev-version.

While incorporating the required change, I found an issue of GitHub action while differentiating the input parameter between empty or not set in a reusable workflow and it is already an open issue at GitHub. Here is the reference -  [https://github.com/actions/runner/issues/924](https://github.com/actions/runner/issues/924 )

Hence, I needed to do it using condition construct. 

Thank you!
