### PR TITLE
Feature/afi 1530

### DIFF
--- a/.github/actions/setup-java-build/action.yml
+++ b/.github/actions/setup-java-build/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: the location of the custom Maven settings.xml file to install
     default: ".ci.settings.xml"
     required: false
+  configure-toolchains:
+    description: configure toolchains.xml
+    default: "false"
+    required: false
+  maven-toolchains:
+    description: the location of the custom Maven toolchains.xml file to install
+    default: ".ci.toolchains.xml"
+    required: false
 runs:
   using: composite
   steps:
@@ -40,3 +48,14 @@ runs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
         overwrite-settings: false
+    - name: "Install ${{ inputs.maven-toolchains }}"
+      if: ${{ inputs.configure-toolchains }}
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.maven-toolchains }}" ]; then
+          echo "Installing Maven toolchains file found in the repository: ${{ inputs.maven-toolchains }}"
+          cp "${{ inputs.maven-toolchains }}" $HOME/.m2/toolchains.xml
+        else
+          echo "Maven toolchains file: ${{ inputs.maven-toolchains }} not found in the repository. Installing the default one"
+          cp ${{ github.action_path }}/toolchains.xml $HOME/.m2/toolchains.xml
+        fi

--- a/.github/actions/setup-java-build/toolchains.xml
+++ b/.github/actions/setup-java-build/toolchains.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains
+	xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>17</version>
+		</provides>
+		<configuration>
+			<jdkHome>${env.JAVA_HOME}</jdkHome>
+		</configuration>
+	</toolchain>
+</toolchains>

--- a/.github/actions/setup-java-build/toolchains.xml
+++ b/.github/actions/setup-java-build/toolchains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<toolchains
+<toolchains>
 	xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
 	<toolchain>

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -70,10 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.38.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@feature/AFI-1530
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
+          configure-toolchains: ${{ inputs.configure-toolchains }}
       - name: "Build"
         if: ${{ inputs.skip-tests }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.38.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@feature/AFI-1530
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -42,6 +42,11 @@ on:
         description: additional Maven build options
         type: string
         required: false
+      configure-toolchains:
+        description: configure toolchains.xml
+        default: false
+        type: boolean
+        required: false
 
     secrets:
         BOT_GITHUB_USERNAME:
@@ -111,6 +116,7 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
+          configure-toolchains: ${{ inputs.configure-toolchains }}
       - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.38.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}


### PR DESCRIPTION
We need to incorporate the installation process of toolchains.xml during the build process of a few of the alfresco SAP connector projects.

I have added two following parameters,
1. **configure-toolchains** (Added in order to keep the backward compatibility for those projects which don't need the toolchains.xml file)
2. **maven-toolchains**

Repository which is using alfresco-build-tools actions are as follows. I have tested the flow and it is working fine.
1. [https://github.com/Alfresco/sap-connector-build-tools/blob/feature/AFI-1530/.github/actions/build-and-test-maven/action.yml](https://github.com/Alfresco/sap-connector-build-tools/blob/feature/AFI-1530/.github/actions/build-and-test-maven/action.yml)
2. [https://github.com/Alfresco/sap-connector-build-tools/blob/feature/AFI-1530/.github/workflows/release-and-dryrun.yml](https://github.com/Alfresco/sap-connector-build-tools/blob/feature/AFI-1530/.github/workflows/release-and-dryrun.yml)

Sample project which need the toolchains.xml is as follows,
[https://github.com/Alfresco/sap-content-connector-accelerator/tree/feature/AFI-1530](https://github.com/Alfresco/sap-content-connector-accelerator/tree/feature/AFI-1530)


 