### PR TITLE
AAE-14315 restore login to quay.io

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -21,6 +21,12 @@ inputs:
   maven-password:
     description: Nexus password
     required: true
+  quay-username:
+    description: Quay.io user name
+    required: false
+  quay-password:
+    description: Quay.io password
+    required: false
   upload-jars:
     description: whether jar files should be uploaded or not as part of the build
     required: false
@@ -117,6 +123,14 @@ runs:
         registry: docker.io
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
+
+    - name: Login to Quay.io Docker Registry
+      if: inputs.quay-username != ''
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ inputs.quay-username }}
+        password: ${{ inputs.quay-password }}
 
     - name: Define Maven Command
       id: define_maven_command


### PR DESCRIPTION
Even if we are not longer pushing docker images from here we need to login to Quay in order to pull som images during the tests.