### PR TITLE
AAE-13340 enable testcontainers reuse

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -156,7 +156,9 @@ runs:
     - name: Enable testcontainers reuse option
       if: inputs.reuse-testcontainers == 'true'
       shell: bash
-      run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
+      run: | 
+        echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
+        echo "TESTCONTAINERS_RYUK_DISABLED=true" >> $GITHUB_ENV
 
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: whether coverage files should be uploaded or not as part of the build
     required: false
     default: 'false'
+  reuse-testcontainers:
+    description: Whether testcontainers should be reused
+    required: false
+    default: 'false'
 
 outputs:
   version:
@@ -149,6 +153,11 @@ runs:
       env:
         DO_PUSH: ${{ github.event_name == 'push' || env.IS_PREVIEW == 'true' }}
 
+    - name: Enable testcontainers reuse option
+      if: inputs.reuse-testcontainers == 'true'
+      shell: bash
+      run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
+
     - name: Build and Test with Maven (and maybe Deploy)
       shell: bash
       run: mvn ${{ steps.define_maven_command.outputs.command }} ${{ env.MAVEN_CLI_OPTS}} ${{ inputs.extra-maven-opts }}
@@ -156,6 +165,11 @@ runs:
         MAVEN_CLI_OPTS: ${{ steps.compute-maven-options.outputs.result }} -Dlogging.root.level=off -Dspring.main.banner-mode=off -Ddocker.skip
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_PASSWORD: ${{ inputs.maven-password }}
+
+    - name: Remove running docker containers
+      if: inputs.reuse-testcontainers == 'true'
+      shell: bash
+      run: docker rm -f $(docker ps -a -q)
 
     - uses: actions/upload-artifact@v3
       if: inputs.upload-jars == 'true'

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -156,7 +156,7 @@ runs:
     - name: Enable testcontainers reuse option
       if: inputs.reuse-testcontainers == 'true'
       shell: bash
-      run: | 
+      run: |
         echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
         echo "TESTCONTAINERS_RYUK_DISABLED=true" >> $GITHUB_ENV
 


### PR DESCRIPTION
Add option to enable reuse of testcontainers to speed up build process.
Documented feature: https://alfresco.atlassian.net/wiki/spaces/HXP/pages/1275265126/PoC+Parallel+Testing+Multi-Thread+Maven+Build#TestContainers-Reuse