### PR TITLE
[AAE-15185] Add step of uploading coverage report in maven-build-and-tag

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -171,7 +171,7 @@ runs:
         name: coverage
         retention-days: 1
         path: |
-          **/target/site/jacoco-aggregate/*
+          **/target/site/jacoco-aggregate/jacoco.xml
 
     - name: Echo Longest Tests run
       shell: bash


### PR DESCRIPTION
as the title says in this PR it was added the upload of the coverage report if required.

https://alfresco.atlassian.net/browse/AAE-15185