### PR TITLE
[AAE-15706] Change java version for failing workflow

### DIFF
--- a/.github/workflows/publish-artifacts-for-veracode.yml
+++ b/.github/workflows/publish-artifacts-for-veracode.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 


### PR DESCRIPTION
This PR fix the failing workflow due to java 11, so this will change it to java 17