### PR TITLE
Adding ADDITIONAL_SETTINGS usage to veracode scan job. Pipeline scans…

### DIFF
--- a/.github/actions/veracode/action.yml
+++ b/.github/actions/veracode/action.yml
@@ -19,5 +19,5 @@ runs:
       shell: bash
       env:
         SRCCLR_API_TOKEN: ${{ inputs.srcclr-api-token }}
-        SRCCLR_INSTALL_DEFAULT_OPTIONS: ${{ srcclr-install-default-options }}
+        SRCCLR_INSTALL_DEFAULT_OPTIONS: ${{ inputs.srcclr-install-default-options }}
         SRCCLR_INSTALL_OPTIONS: ${{ inputs.srcclr-install-options }}

--- a/.github/actions/veracode/action.yml
+++ b/.github/actions/veracode/action.yml
@@ -4,6 +4,13 @@ inputs:
   srcclr-api-token:
     description: "Agent API Token"
     required: true
+  srcclr-install-default-options:
+    description: Default options for Source Clear scan
+    required: false
+    default: '-DskipTests -Dmaven.javadoc.skip=true'
+  srcclr-install-options:
+    description: Additional options for Source Clear scan
+    required: false
 runs:
   using: "composite"
   steps:
@@ -12,3 +19,5 @@ runs:
       shell: bash
       env:
         SRCCLR_API_TOKEN: ${{ inputs.srcclr-api-token }}
+        SRCCLR_INSTALL_DEFAULT_OPTIONS: ${{ srcclr-install-default-options }}
+        SRCCLR_INSTALL_OPTIONS: ${{ inputs.srcclr-install-options }}

--- a/.github/actions/veracode/source_clear.sh
+++ b/.github/actions/veracode/source_clear.sh
@@ -9,7 +9,7 @@ mvn -B -q clean install \
     -Dmaven.javadoc.skip=true \
     com.srcclr:srcclr-maven-plugin:scan \
     -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log \
-    $ADDITIONAL_SETTINGS
+    ${ADDITIONAL_SETTINGS}
 
 SUCCESS=$?   # this will read exit code of the previous command
 

--- a/.github/actions/veracode/source_clear.sh
+++ b/.github/actions/veracode/source_clear.sh
@@ -5,11 +5,9 @@ PS4="\[\e[35m\]+ \[\e[m\]"
 set +e -v -x
 
 mvn -B -q clean install \
-    -DskipTests \
-    -Dmaven.javadoc.skip=true \
+    ${SRCCLR_INSTALL_DEFAULT_OPTIONS} ${SRCCLR_INSTALL_OPTIONS} \
     com.srcclr:srcclr-maven-plugin:scan \
-    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log \
-    ${ADDITIONAL_SETTINGS}
+    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log
 
 SUCCESS=$?   # this will read exit code of the previous command
 

--- a/.github/actions/veracode/source_clear.sh
+++ b/.github/actions/veracode/source_clear.sh
@@ -8,7 +8,8 @@ mvn -B -q clean install \
     -DskipTests \
     -Dmaven.javadoc.skip=true \
     com.srcclr:srcclr-maven-plugin:scan \
-    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log
+    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log \
+    $ADDITIONAL_SETTINGS
 
 SUCCESS=$?   # this will read exit code of the previous command
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1203,7 +1203,7 @@ Validates Maven dependency graph versions to ensure all target includes artifact
 
 ### veracode
 
-Runs Veracode Source Clear Scan, allows for adding additional maven options to 
+Runs Veracode Source Clear Scan
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@ref

--- a/docs/README.md
+++ b/docs/README.md
@@ -1203,13 +1203,14 @@ Validates Maven dependency graph versions to ensure all target includes artifact
 
 ### veracode
 
-Runs Veracode Source Clear Scan
+Runs Veracode Source Clear Scan, allows for adding additional maven options to 
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@ref
         #continue-on-error: true # uncomment this line to prevent the Veracode scan step from failing the whole build
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
+          srcclr-install-options: '-DskipTestModules' # optional, additional maven options
 ```
 
 ## Reusable workflows provided by us


### PR DESCRIPTION
… that include test modules, which aren't present in release artifacts, often show up in SCA scans of components creating a false sense of vulnerability, that isn't there. Test modules should be excluded from releases and from security scans, but no other way than directly amending this command would work