### PR TITLE
OPSEXP-2225 Fixup links in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 ### Checklist
 
 - Jira Reference (also in PR title):
-- [README](/docs/README.md) updated after adding/changing behaviour of an action
-- Proposed version increment for [release](/docs/README.md#release):
+- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
+- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
   - [ ] Patch (bugfix)
   - [ ] Minor (new feature)
   - [ ] Major (breaking changes)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-2225
- [README](/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Current links are pointing to https://github.com/docs/README.md 😕 
