### PR TITLE
OPSEXP-2242: better control of ingress version in setup kind action

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -8,6 +8,10 @@ inputs:
       https://github.com/kubernetes-sigs/kind/releases
     required: true
     default: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+  nginx-manifest:
+    description: The nginx manifest to apply.
+    required: true
+    default: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 runs:
   using: "composite"
   steps:
@@ -19,11 +23,8 @@ runs:
 
     - name: Install ingress-nginx
       shell: bash
-      env:
-        NGINX_MANIFEST: |
-          https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
       run: |
-        kubectl apply -f $NGINX_MANIFEST
+        kubectl apply -f ${{ inputs.nginx-manifest }}
 
     - name: Wait for ingress ready
       shell: bash

--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -8,10 +8,13 @@ inputs:
       https://github.com/kubernetes-sigs/kind/releases
     required: true
     default: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
-  nginx-manifest:
-    description: The nginx manifest to apply.
-    required: true
-    default: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+  nginx-ingress-ref:
+    description: |
+      the Nginx ingress ref to get the ingress congtroller deployment manifest from
+      (https://github.com/kubernetes/ingress-nginx). Consider main (the default) a floating tag which can result in
+      deploying any version (including betas) and non repeatable builds.
+    required: false
+    default: main
 runs:
   using: "composite"
   steps:
@@ -23,8 +26,11 @@ runs:
 
     - name: Install ingress-nginx
       shell: bash
+      env:
+        NGINX_MANIFEST_URL: >-
+          https://raw.githubusercontent.com/kubernetes/ingress-nginx/${{ inputs.nginx-ingress-ref }}/deploy/static/provider/kind/deploy.yaml
       run: |
-        kubectl apply -f ${{ inputs.nginx-manifest }}
+        kubectl apply -f "${NGINX_MANIFEST_URL}"
 
     - name: Wait for ingress ready
       shell: bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1176,14 +1176,17 @@ Spin up a local kubernetes cluster with nginx ingress exposing http/https ports.
 ```yaml
       - name: Setup cluster
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-kind@ref
-        # with:
+        with:
           # See the available refs in the kind release notes at https://github.com/kubernetes-sigs/kind/releases
           # kind-node-image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+          nginx-ingress-ref: controller-v1.8.2
       - name: Helm deploy
         run: |
           helm dep up ./helm/chart
           helm install acs ./helm/chart
 ```
+
+> Although not required we recommend setting the `nginx-ingress-ref``to ensure repeatable builds
 
 ### update-project-base-tag
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/acs-deployment/actions/runs/6223791154/job/16890563627#step:9:49

### Description

add a new `nginx-ingress-ref`parameter to allow pining the ingress version/conf
