### PR TITLE
Reduce dependabot PRs for our actions by grouping updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,267 +21,535 @@ updates:
     directory: "/.github/actions/automate-dependabot"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/automate-propagation"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/calculate-next-internal-version"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/configure-git-author"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/dbp-charts/kubernetes-valid-ns"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/dbp-charts/publish-chart"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/dbp-charts/verify-compose"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/dbp-charts/verify-helm"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/docker-build-image"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/docker-dump-containers-logs"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/docker-scan-image-dirs"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/env-load-from-yaml"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/free-hosted-runner-disk-space"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/get-branch-name"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/get-build-info"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/get-commit-message"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/gh-cache-cleanup-on-merge"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/git-check-existing-tag"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/git-commit-changes"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/git-latest-tag"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/github-download-file"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-build-chart"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-integration-tests"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-package-chart"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-parse-next-release"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-plugin"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-publish-chart"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-release-and-publish"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-template-yamllint"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/helm-update-chart-version"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/jx-updatebot-pr"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/kubectl-keep-nslogs"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/load-release-descriptor"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/maven-build-and-tag"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/maven-deploy-file"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/maven-release"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/maven-update-pom-version"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/nexus-close-staging"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/nexus-create-staging"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/nexus-release-staging"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/pipenv"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/pre-commit-default"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/pre-commit"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/process-coverage-report"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/rancher"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/reportportal-prepare"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/reportportal-summarize"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/resolve-preview-name"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/send-slack-notification-slow-job"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/send-slack-notification"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/send-teams-notification"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-github-release-binary"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-helm-docs"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-java-build"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-jx-release-version"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-kcadm"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-kind"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-kubepug"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-pysemver"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-rancher-cli"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-terraform-docs"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-updatebot"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/update-deployment-runtime-versions"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/update-pom-to-next-pre-release"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/update-project-base-tag"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/validate-maven-versions"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/veracode"
     schedule:
       interval: "weekly"
+    groups:
+      catch-all:
+        patterns:
+          - "*"

--- a/update-dependabot.sh
+++ b/update-dependabot.sh
@@ -15,10 +15,16 @@ temp_config='temp_dependabot.yml'
 # Function to generate Dependabot config section for a composite action
 generate_dependabot_section() {
     local action_dir=$1
-    echo "  - package-ecosystem: \"github-actions\""
-    echo "    directory: \"/${action_dir}\""
-    echo "    schedule:"
-    echo "      interval: \"weekly\""
+    cat <<END
+- package-ecosystem: "github-actions"
+  directory: "/${action_dir}"
+  schedule:
+    interval: "weekly"
+  groups:
+    catch-all:
+      patterns:
+        - "*"
+END
 }
 
 # Check if Dependabot config exists
@@ -28,17 +34,17 @@ if [ ! -f "$master_config" ]; then
 fi
 
 # Start building the new config section
-echo "version: 2" > "$temp_config"
-echo "updates:" >> "$temp_config"
+echo "version: 2" >"$temp_config"
+echo "updates:" >>"$temp_config"
 
 # Loop through composite actions and append to temp config
 for action_filename in $(find "$actions_dir" -mindepth 2 -type f -name action.yml | env -i LC_COLLATE=C sort -n); do
     action_dir=$(dirname $action_filename)
-    generate_dependabot_section "$action_dir" >> "$temp_config"
+    generate_dependabot_section "$action_dir" >>"$temp_config"
 done
 
 # Merge new section with existing Dependabot config using yq
-yq eval-all '. as $item ireduce ({}; . *+ $item)' $master_config $temp_config > "$dependabot_config"
+yq eval-all '. as $item ireduce ({}; . *+ $item)' $master_config $temp_config >"$dependabot_config"
 
 # Clean up
 rm "$temp_config"

--- a/update-dependabot.sh
+++ b/update-dependabot.sh
@@ -34,17 +34,17 @@ if [ ! -f "$master_config" ]; then
 fi
 
 # Start building the new config section
-echo "version: 2" >"$temp_config"
-echo "updates:" >>"$temp_config"
+echo "version: 2" > "$temp_config"
+echo "updates:" >> "$temp_config"
 
 # Loop through composite actions and append to temp config
 for action_filename in $(find "$actions_dir" -mindepth 2 -type f -name action.yml | env -i LC_COLLATE=C sort -n); do
     action_dir=$(dirname $action_filename)
-    generate_dependabot_section "$action_dir" >>"$temp_config"
+    generate_dependabot_section "$action_dir" >> "$temp_config"
 done
 
 # Merge new section with existing Dependabot config using yq
-yq eval-all '. as $item ireduce ({}; . *+ $item)' $master_config $temp_config >"$dependabot_config"
+yq eval-all '. as $item ireduce ({}; . *+ $item)' $master_config $temp_config > "$dependabot_config"
 
 # Clean up
 rm "$temp_config"


### PR DESCRIPTION
### Description

Instead of:
![image](https://github.com/Alfresco/alfresco-build-tools/assets/71768/3b11851e-b743-4222-9eb9-74c15f6c18d3)

we'll get a single PR with both updates, but only for updates within the same action.