### PR TITLE
docs: add generate-dependabot-glob-action in readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,12 +23,12 @@ Here follows the list of GitHub Actions topics available in the current document
     - [Docker build and push](#docker-build-and-push)
     - [Docker login](#docker-login)
     - [EC2 GitHub runner](#ec2-github-runner)
+    - [Generate Dependabot Glob Action](#generate-dependabot-glob-action)
     - [Git commit and push](#git-commit-and-push)
     - [pmd](#pmd)
     - [Retry failing step](#retry-failing-step)
     - [SSH debug](#ssh-debug)
     - [Triggering a workflow in another repository](#triggering-a-workflow-in-another-repository)
-    - [Generate Dependabot Glob Action](#generate-dependabot-glob-action)
   - [GitHub Actions provided by us](#github-actions-provided-by-us)
     - [automate-dependabot](#automate-dependabot)
     - [automate-propagation](#automate-propagation)
@@ -205,6 +205,35 @@ provided as repository secrets.
 
 [machulav/ec2-github-runner](https://github.com/machulav/ec2-github-runner) can be used to start EC2 [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners). An on-demand EC2 runner can be created, set-up, used to run a required process and finally destroyed - on the fly.
 
+### Generate Dependabot Glob Action
+
+[generate-dependabot-glob-action](https://github.com/Makeshift/generate-dependabot-glob-action) creates a dependabot.yml file from a user-provided template by replacing instances of directory globs with an array of objects matching that glob, with all the other keys copied.
+For example, the following template:
+
+```yml
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/*/Dockerfile*'
+    schedule:
+      interval: 'daily'
+```
+
+Will result in:
+
+```yml
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/container_1/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/container_2/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/weird_dockerfile/'
+    schedule:
+      interval: 'daily'
+```
+
 ### Git commit and push
 
 [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)
@@ -313,32 +342,6 @@ on the default branch):
 on:
   # allows triggering workflow manually or from other jobs
   workflow_dispatch:
-```
-
-### Generate Dependabot Glob Action
-
-[generate-dependabot-glob-action](https://github.com/Makeshift/generate-dependabot-glob-action) creates a dependabot.yml file from a user-provided template by replacing instances of directory globs with an array of objects matching that glob, with all the other keys copied.
-For example, the following template:
-```
-  - package-ecosystem: 'docker'
-    directory: '/test/docker/*/Dockerfile*'
-    schedule:
-      interval: 'daily'
-```
-Will result in:
-```
-  - package-ecosystem: 'docker'
-    directory: '/test/docker/container_1/'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'docker'
-    directory: '/test/docker/container_2/'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'docker'
-    directory: '/test/docker/weird_dockerfile/'
-    schedule:
-      interval: 'daily'
 ```
 
 ## GitHub Actions provided by us

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Here follows the list of GitHub Actions topics available in the current document
     - [Retry failing step](#retry-failing-step)
     - [SSH debug](#ssh-debug)
     - [Triggering a workflow in another repository](#triggering-a-workflow-in-another-repository)
+    - [Generate Dependabot Glob Action](#generate-dependabot-glob-action)
   - [GitHub Actions provided by us](#github-actions-provided-by-us)
     - [automate-dependabot](#automate-dependabot)
     - [automate-propagation](#automate-propagation)
@@ -312,6 +313,32 @@ on the default branch):
 on:
   # allows triggering workflow manually or from other jobs
   workflow_dispatch:
+```
+
+### Generate Dependabot Glob Action
+
+[generate-dependabot-glob-action](https://github.com/Makeshift/generate-dependabot-glob-action) creates a dependabot.yml file from a user-provided template by replacing instances of directory globs with an array of objects matching that glob, with all the other keys copied.
+For example, the following template:
+```
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/*/Dockerfile*'
+    schedule:
+      interval: 'daily'
+```
+Will result in:
+```
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/container_1/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/container_2/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/test/docker/weird_dockerfile/'
+    schedule:
+      interval: 'daily'
 ```
 
 ## GitHub Actions provided by us


### PR DESCRIPTION

- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action

### Description
Add generate-dependabot-glob-action documentation to _GitHub Actions provided by community_ section.