### PR TITLE
AAE-20957 Allow releasing on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
     - closed
+  workflow_dispatch:
 
 jobs:
     release:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->
Release for https://github.com/Alfresco/alfresco-build-tools/pull/528 did not kick in (because of skip ci marker in one of the commits?) this allows unblocking
