### PR TITLE
OPSEXP-2758 Drop workaround for setuptools incident after upstream fix

### DIFF
--- a/.github/actions/setup-pysemver/action.yml
+++ b/.github/actions/setup-pysemver/action.yml
@@ -8,15 +8,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Apply workaround for pypa/setuptools#4519
-      shell: bash
-      run: |
-        echo "setuptools<72" > ${{ runner.temp }}/python-constraints.txt
-
     - name: Install pysemver via pip
       env:
         TOOL_VERSION: ${{ inputs.version }}
-        PIP_CONSTRAINT: ${{ runner.temp }}/python-constraints.txt
       run: |
         pip3 install git+https://github.com/python-semver/python-semver.git@$TOOL_VERSION
         pysemver --version


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-2758

### Description

<!-- Explain your changes -->

A new version of setuptools has been released which doesn't wreak the havoc for libraries still using the now deprecated feature.

https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7210