### PR TITLE
OPSEXP-2255 Refactor verify-compose action to wait for running|healthy state of containers

### DIFF
--- a/.github/actions/dbp-charts/verify-compose/docker_compose.sh
+++ b/.github/actions/dbp-charts/verify-compose/docker_compose.sh
@@ -11,20 +11,6 @@ dump_all_compose_logs() {
   exit 1
 }
 
-wait_result() {
-  COMPONENT=$1
-  if (("${COUNTER}" < "${TIMEOUT}")); then
-    t1=$(date +%s)
-    delta=$(((t1 - t0) / 60))
-    echo "$COMPONENT Started in ${delta} minutes"
-  else
-    echo "Waited ${COUNTER} seconds"
-    echo "$COMPONENT could not start in time."
-    echo "The last response code was ${response}"
-    dump_all_compose_logs
-  fi
-}
-
 cd "$COMPOSE_PATH" || {
   echo "Error: docker compose dir not found"
   exit 1
@@ -38,46 +24,7 @@ if [ "$COMPOSE_PULL" = "true" ]; then
   $COMPOSE_BIN -f "${COMPOSE_FILE}" pull --quiet
 fi
 export COMPOSE_HTTP_TIMEOUT=120
-$COMPOSE_BIN -f "${COMPOSE_FILE}" up -d --quiet-pull
-
-WAIT_INTERVAL=1
-COUNTER=0
-TIMEOUT=300
-t0=$(date +%s)
-echo "Waiting for alfresco to start"
-response=$(curl --write-out '%{http_code}' --output /dev/null --silent http://localhost:"${alf_port}"/alfresco/ || true)
-until [[ "200" -eq "${response}" ]] || [[ "${COUNTER}" -eq "${TIMEOUT}" ]]; do
-  printf '.'
-  sleep "${WAIT_INTERVAL}"
-  COUNTER=$((COUNTER + WAIT_INTERVAL))
-  response=$(curl --write-out '%{http_code}' --output /dev/null --silent http://localhost:"${alf_port}"/alfresco/ || true)
-done
-wait_result Alfresco
-
-COUNTER=0
-echo "Waiting for share to start"
-response=$(curl --write-out '%{http_code}' --output /dev/null --silent http://localhost:8080/share/page || true)
-until [[ "200" -eq "${response}" ]] || [[ "${COUNTER}" -eq "${TIMEOUT}" ]]; do
-  printf '.'
-  sleep "${WAIT_INTERVAL}"
-  COUNTER=$((COUNTER + WAIT_INTERVAL))
-  response=$(curl --write-out '%{http_code}' --output /dev/null --silent http://localhost:8080/share/page || true)
-done
-wait_result Share
-
-if [ $($COMPOSE_BIN -f "${COMPOSE_FILE}" config | yq '.services.alfresco.environment.JAVA_OPTS | contains(" -Dindex.subsystem.name=solr6")') == "true" ]; then echo "Waiting more time for SOLR"
-  COUNTER=0
-  TIMEOUT=20
-
-  response=$(curl --write-out '%{http_code}' --user admin:admin --output /dev/null --silent http://localhost:"${alf_port}"/alfresco/s/api/solrstats || true)
-  until [[ "200" -eq "${response}" ]] || [[ "${COUNTER}" -eq "${TIMEOUT}" ]]; do
-    printf '.'
-    sleep "${WAIT_INTERVAL}"
-    COUNTER=$((COUNTER + WAIT_INTERVAL))
-    response=$(curl --write-out '%{http_code}' --user admin:admin --output /dev/null --silent http://localhost:"${alf_port}"/alfresco/s/api/solrstats || true)
-  done
-  wait_result Solr
-fi
+$COMPOSE_BIN -f "${COMPOSE_FILE}" up -d --quiet-pull --wait
 
 cd ..
 docker run -a STDOUT --volume "${PWD}"/test/postman/docker-compose:/etc/newman --network host postman/newman:5.3 run "acs-test-docker-compose-collection.json" --global-var "protocol=http" --global-var "url=localhost:8080"

--- a/.github/actions/dbp-charts/verify-compose/docker_compose.sh
+++ b/.github/actions/dbp-charts/verify-compose/docker_compose.sh
@@ -26,6 +26,8 @@ fi
 export COMPOSE_HTTP_TIMEOUT=120
 $COMPOSE_BIN -f "${COMPOSE_FILE}" up -d --quiet-pull --wait
 
+echo "All services are up and running... starting postman tests"
+
 cd ..
 docker run -a STDOUT --volume "${PWD}"/test/postman/docker-compose:/etc/newman --network host postman/newman:5.3 run "acs-test-docker-compose-collection.json" --global-var "protocol=http" --global-var "url=localhost:8080"
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-2255
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [x] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/acs-deployment/pull/1232

### Description

`verify-compose` action now does not check the response from services - behavior is changed to use the `--wait `flag on `docker compose` command which waits for services with defined healthcheck to be healthy or without healthcheck to be running
