### PR TITLE
AAE-29961 Fix link to reportportal launch when using ubuntu 24

### DIFF
--- a/.github/actions/reportportal-summarize/get-rp-output.sh
+++ b/.github/actions/reportportal-summarize/get-rp-output.sh
@@ -5,7 +5,7 @@ URL=''
 
 # support spaces on launch key
 urlEncode() {
-  echo $1 | curl -Gso /dev/null -w %{url_effective} --data-urlencode @- "" | sed -E 's/..(.*).../\1/'
+  echo $1 | python -c "import urllib.parse, sys; print(urllib.parse.quote(sys.stdin.read()))" | sed -E 's/(.*).../\1/' | tr -d '\n'
 }
 
 if [[ -n "$RP_LAUNCH_KEY" && -n "$RP_TOKEN" && -n "$RP_URL" && -n "$RP_PROJECT" ]]


### PR DESCRIPTION
Just use python to urlencode instead of curl

<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->
