### PR TITLE
AAE-33027 Update docs to create Teams Webhooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1566,7 +1566,7 @@ Sends a teams notification with a pre-defined payload.
         webhook-url: ${{ secrets.MSTEAMS_WEBHOOK }}
 ```
 
-The above webhook URL is a mandatory parameter. Make sure to [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet) before using this action. Add the webhook URL as a `secret` at the repo level.
+The above webhook URL is a mandatory parameter. Make sure to [Create Incoming Webhooks](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498) before using this action. Add the webhook URL as a `secret` at the repo level.
 
 If the `status` input is not filled, it will be computed based on the status of completed steps in currently running workflow.
 The workflow permissions will require "actions: read" in this case.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Just updating the README to mention the correct latest way of creating Teams Webhooks as the previously documented one is referring to deprecated Webhooks that are going to reach EoL by end of year.
