### PR TITLE
OPSEXP-3314 setup-github-release-binary: fixup automatic handling of arch

### DIFF
--- a/.github/actions/setup-github-release-binary/action.yml
+++ b/.github/actions/setup-github-release-binary/action.yml
@@ -26,7 +26,12 @@ runs:
       run: |
         NAME=${NAME:-${REPO##*\/}}
         OS=${OS:-$(uname | tr '[:upper:]' '[:lower:]')}
-        ARCH=${ARCH:-$(uname -m)}
+        ARCH_RAW=$(uname -m)
+        case $ARCH_RAW in
+          x86_64) ARCH=${ARCH:-amd64} ;;
+          aarch64) ARCH=${ARCH:-arm64} ;;
+          *) ARCH=${ARCH:-$ARCH_RAW} ;;
+        esac
         URL=https://github.com/$REPO/releases/download/$(eval echo $URL_TEMPLATE)
         echo "Downloading $URL ..."
         curl -fsSL $URL | tar xz $NAME


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-3314
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->
