### PR TITLE
Fix updatecli workflow trigger after a release

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
+    tags-ignore:
+      - '**'
     paths:
       - '.updatecli/**'
       - .github/workflows/updatecli.yml


### PR DESCRIPTION
### Description

There is no need to run updatecli workflow upon a release like in https://github.com/Alfresco/alfresco-build-tools/actions/runs/17062594838
