### PR TITLE
OPSEXP-3342 Allow overriding binary name in setup-github-release-binary

### DIFF
--- a/.github/actions/setup-github-release-binary/action.yml
+++ b/.github/actions/setup-github-release-binary/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Override the package architecture when aarch64'
     required: false
     default: 'arm64'
-  name:
+  binary_name:
     description: 'Override the binary name, defaults to repo name'
     required: false
     default: ''
@@ -35,9 +35,9 @@ runs:
         REPO: ${{ inputs.repo }}
         VERSION: ${{ inputs.version }}
         URL_TEMPLATE: ${{ inputs.url_template }}
-        NAME: ${{ inputs.name }}
+        BINARY_NAME: ${{ inputs.binary_name }}
       run: |
-        NAME=${NAME:-${REPO##*\/}}
+        NAME=${BINARY_NAME:-${REPO##*\/}}
         OS=${OS:-$(uname | tr '[:upper:]' '[:lower:]')}
         ARCH_RAW=$(uname -m)
         case $ARCH_RAW in


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-3342
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-eks-clusters/pull/16

### Description

Introducing a new optional `name` input to allow overriding the default binary name in case it is not using the same name of the repository.

(will release later)
