### PR TITLE
OPSEXP-3531 add branch promotion reusable workflow

### DIFF
--- a/.github/workflows/branch-promotion-prs.yml
+++ b/.github/workflows/branch-promotion-prs.yml
@@ -1,0 +1,58 @@
+name: Automated Branch Promotion PRs
+
+on:
+  workflow_call:
+    inputs:
+      source-branch:
+        description: 'Source branch to promote from'
+        type: string
+        default: 'develop'
+      target-branches:
+        description: 'JSON array of target branches to promote to'
+        type: string
+        required: true
+      pr-title-template:
+        description: 'Template for PR title (use {0} placeholder for branch)'
+        type: string
+        default: 'Update {0} env'
+      pr-body-template:
+        description: 'Template for PR body (use {0} for branch and {1} for source placeholders)'
+        type: string
+        default: 'This PR updates the {0} environment with the latest changes from the {1} branch.'
+      draft-pr:
+        description: 'Create PRs as drafts'
+        type: boolean
+        default: true
+    secrets:
+      gh-token:
+        description: 'GitHub token for creating PRs'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  promotion:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ fromJson(inputs.target-branches) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Reset promotion branch
+        run: |
+          git fetch origin ${{ inputs.source-branch }}
+          git reset --hard origin/${{ inputs.source-branch }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          branch: ${{ inputs.source-branch }}
+          title: ${{ format(inputs.pr-title-template, matrix.branch) }}
+          draft: ${{ inputs.draft-pr }}
+          body: ${{ format(inputs.pr-body-template, matrix.branch, inputs.source-branch) }}
+          token: ${{ secrets.gh-token }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,7 +127,8 @@ Here follows the list of GitHub Actions topics available in the current document
     - [validate-maven-versions](#validate-maven-versions)
     - [veracode](#veracode)
   - [Reusable workflows provided by us](#reusable-workflows-provided-by-us)
-    - [helm-publish-new-package-version.yml](#helm-publish-new-package-versionyml)
+    - [branch-promotion-prs](#branch-promotion-prs)
+    - [helm-publish-new-package-version](#helm-publish-new-package-version)
     - [terraform](#terraform)
   - [Cookbook](#cookbook)
     - [Conditional job/step depending on PR labels](#conditional-jobstep-depending-on-pr-labels)
@@ -2163,7 +2164,35 @@ This way, the agent-based scan results will be added in the latest promoted scan
 
 ## Reusable workflows provided by us
 
-### helm-publish-new-package-version.yml
+### branch-promotion-prs
+
+Automates the creation of pull requests to promote changes from a source branch to multiple target branches. This workflow is useful for promoting changes across different environments (e.g., from develop to staging and production branches).
+
+```yaml
+name: Promote to Environment Branches
+
+on:
+  push:
+    branches:
+      - 'develop'  # Source branch to monitor for changes
+
+permissions:
+  contents: write  # Required to create pull requests
+
+jobs:
+  promote:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/branch-promotion-prs.yml@ref
+    with:
+      source-branch: 'develop' # default branch to promote from
+      target-branches: '["staging", "production"]' # JSON array of branches to promote to
+      pr-title-template: 'Promote to {0} environment' # optional
+      pr-body-template: 'This PR promotes the latest changes from {1} to the {0} environment.' # optional
+      draft-pr: false
+    secrets:
+      gh-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### helm-publish-new-package-version
 
 Calculates the new alpha version, creates new git tag and publishes the new package to the helm chart repository
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -173,17 +173,11 @@ jobs:
     secrets: inherit
 ```
 
-## Environment badges
+## Branch promotion workflow
 
-At the top of the README file, you should list a badge for every configured environment, to ease raising PRs to keep them up to date. You can use the following Markdown snippet to add a badge for each environment:
+For Terraform projects with multiple environment branches, you can use the
+branch promotion workflow to automate the creation of pull requests when
+promoting changes across environments.
 
-```markdown
-[![update ENV-NAME env](https://img.shields.io/badge/⚠️-update%20ENV--NAME%20env-blue)](https://github.com/Alfresco/REPO-NAME/compare/ENV-NAME...develop?expand=1&title=Update%20ENV-NAME%20env)
-```
-
-Replace `REPO-NAME` with the name of the GitHub repository and `ENV-NAME` with
-the name of the environment (e.g., `development`, `staging`, `production`) which
-also correspond to the branch name.
-
-Please note that `img.shields.io` badge also requires escaping single dash to
-double dash to work properly.
+See [main documentation](README.md#branch-promotion-prs) for usage
+documentation.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-3531
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

introduce a new reusable workflow for automating branch promotions and updates the documentation to reflect its usage. The main focus is on streamlining the process of promoting changes from a source branch to multiple target branches, particularly for environment management (e.g., develop → staging/production). Documentation for Terraform projects has also been updated to encourage adoption of this workflow.