### PR TITLE
AAE-40011 Add custom property to skip also unit tests

### DIFF
--- a/.github/actions/maven-configure/action.yml
+++ b/.github/actions/maven-configure/action.yml
@@ -76,7 +76,7 @@ runs:
         NTP='--no-transfer-progress'
         ${{ inputs.verbose }} && NTP=''
         TEST_OPTIONS=''
-        [[ $SKIP_TESTS == 'true' ]] && TEST_OPTIONS='-DskipTests=true -DskipITs=true'
+        [[ $SKIP_TESTS == 'true' ]] && TEST_OPTIONS='-DskipTests=true -DskipITs=true -DskipUTs=true'
         echo "result=--show-version --settings settings.xml $NTP $TEST_OPTIONS" >> $GITHUB_OUTPUT
 
     - name: Set is_preview env variable


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

We introduced a custom property in order to allow us to skip either surefire or failsafe tests plugins so that we can run unit or integration tests separately. Note that skipTests is default for both plugins.

After introducing this property the behaviour of adding the skip-tests label had a side effect, the PR creator now has to wait for couple of mins for the unit tests to run (as skipUTs replaced the skipTests in surefire).  

It is not a big problem to wait for few mins, also there is a new PR created by Elias which will build the images in parallel so the PR creator does not have to wait 2-3mins for the unit tests when using the skip-tests label in the PR.
So we could either merge this PR and fix this problem or ignore this PR for the reasons mentioned above. 
