### PR TITLE
AAE-40141 Fixes docker cleanup

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -201,7 +201,7 @@ runs:
     - name: Remove running docker containers
       if: inputs.reuse-testcontainers == 'true'
       shell: bash
-      run: docker rm -f $(docker ps -a -q)
+      run: docker ps -aq | xargs -r docker rm -f
       continue-on-error: true
 
     - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -158,7 +158,7 @@ runs:
     - name: Remove running docker containers
       if: inputs.reuse-testcontainers == 'true'
       shell: bash
-      run: docker rm -f $(docker ps -a -q)
+      run: docker ps -aq | xargs -r docker rm -f
       continue-on-error: true
 
     - name: Echo Longest Tests run


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): AAE-40141
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:
  - Old behaviour: https://github.com/Alfresco/hxp-process-services/actions/runs/19505850301/job/55831976029
  - New behaviour: https://github.com/Alfresco/hxp-process-services/actions/runs/19567520480/job/56033169487

### Description

It fixes the following error:

<img width="439" height="137" alt="image" src="https://github.com/user-attachments/assets/a2a70148-1b34-473d-b12a-0782334321dc" />.  

by replacing `docker rm -f $(docker ps -a -q)` with `docker ps -aq | xargs -r docker rm -f`
 
<!-- Explain your changes -->
