### PR TITLE
Fix nuxeo testing workflow not bumping the version and running on dependabot PRs

### DIFF
--- a/.github/workflows/test-nuxeo.yml
+++ b/.github/workflows/test-nuxeo.yml
@@ -9,7 +9,7 @@ on:
       - '.github/actions/nuxeo/**'
       - '.github/workflows/test-nuxeo.yml'
   pull_request_review:
-      types: [ submitted ]
+    types: [ submitted ]
 
 jobs:
   nos-publish:


### PR DESCRIPTION

<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Decided to remove the concurrency completely to not interrupt the nos publish as it needs to be deleted after publishing. Now it behaves just like `test.yml` in which we don't define concurrency either. 

<!-- Explain your changes -->
