### PR TITLE
OPSEXP-3722: fix kubectl-keep-nslogs batch logs

### DIFF
--- a/.github/actions/kubectl-keep-nslogs/action.yml
+++ b/.github/actions/kubectl-keep-nslogs/action.yml
@@ -30,8 +30,8 @@ runs:
       working-directory: ${{ steps.artifactdir.outputs.ARTIFACTS_DIR }}
       run: |
         kubectl config set-context --current --namespace=${{ inputs.namespace }}
-        for type in deployment.apps statefulset.apps jobs; do
-          [ -d "${type}" ] || mkdir "${type}"
+        for type in deployment.apps statefulset.apps job.batch; do
+          mkdir -p "${type}"
           for i in $(kubectl get "$type" -o name); do \
             kubectl logs "$i" --all-containers=true > ${i}.log
           done


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/alfresco-content-app/pull/4938

### Description

kubectl-keep-nslogs is using the wrong resource name when creating the folder, thus when creating the log file, the folder does not exist.
For instance jobs resolves as job.batch thus attempting to create job.batch/the_file.log whereas the created folder is jobs.
