### PR TITLE
Avoid tests failure when commit message contain "

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,16 +142,24 @@ jobs:
       - uses: ./.github/actions/get-commit-message
         id: get-full-commit-message
 
-      - run: |
-          echo "Full commit message (output): '${{ steps.get-full-commit-message.outputs.COMMIT_MESSAGE }}'"
-          echo "Full commit message (env): '${{ env.COMMIT_MESSAGE }}'"
+      - name: Test full commit message
+        env:
+          COMMIT_MSG_OUTPUT: ${{ steps.get-full-commit-message.outputs.COMMIT_MESSAGE }}
+          COMMIT_MSG_ENV: ${{ env.COMMIT_MESSAGE }}
+        run: |
+          echo "Full commit message (output): $COMMIT_MSG_OUTPUT"
+          echo "Full commit message (env): $COMMIT_MSG_ENV"
 
       - uses: ./.github/actions/get-commit-message
         id: get-commit-message-header-only
         with:
           header-only: true
 
-      - run: |
-          echo "Full commit message header (output): '${{ steps.get-commit-message-header-only.outputs.COMMIT_MESSAGE }}'"
-          echo "Full commit message header (env): '${{ env.COMMIT_MESSAGE }}'"
+      - name: Test commit message header
+        env:
+          COMMIT_MSG_HEADER_OUTPUT: ${{ steps.get-commit-message-header-only.outputs.COMMIT_MESSAGE }}
+          COMMIT_MSG_HEADER_ENV: ${{ env.COMMIT_MESSAGE }}
+        run: |
+          echo "Full commit message header (output): $COMMIT_MSG_HEADER_OUTPUT"
+          echo "Full commit message header (env): $COMMIT_MSG_HEADER_ENV"
       # endregion


### PR DESCRIPTION
Refactors steps in the `.github/workflows/test.yml` workflow to improve how commit message outputs are handled and echoed during testing. Instead of referencing the commit message outputs directly in the `run` step, the values are now assigned to environment variables, making the output more resilient.

Avoid https://github.com/Alfresco/alfresco-build-tools/actions/runs/21358563867/job/61471811275