### PR TITLE
Allow dependabot recurse in subdirs of actions dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/*"
+      - "/.github/actions/**"
     exclude-paths:
       - "setup-kind/kind.yml"
     schedule:


### PR DESCRIPTION
### Description

Thanks to a failure [here](https://github.com/Alfresco/acs-deployment/actions/runs/21592396620/job/62215616408) I noticed that dependabot is not picking updates for actions which lives in a subfolder of the main actions folder like:
https://github.com/Alfresco/alfresco-build-tools/blame/master/.github/actions/dbp-charts/publish-chart/action.yml#L25

which is not getting automatically updated in the last 6 months - I guess since switching to the new `directories` key in the dependabot.yml file.

upstream docs: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files (not sure it will work like I did here but worth trying first)