### PR TITLE
Allow dependabot recurse in subdirs of actions dir (2nd try)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/**"
+      - "/.github/actions/**/*"
     exclude-paths:
       - "setup-kind/kind.yml"
     schedule:


### PR DESCRIPTION
### Description

The first tentative didn't yield any result, let's try with this new one.
