### PR TITLE
OPSEXP-3981: fix pre-commit when github.head_ref not available in pull_request_review run

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -24,7 +24,7 @@ runs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: inputs.skip_checkout == 'false'
       env:
-        REF_TO_CHECKOUT: ${{ inputs.auto-commit == 'true' && github.head_ref || '' }}
+        REF_TO_CHECKOUT: ${{ inputs.auto-commit == 'true' && github.event.pull_request.head.ref || '' }}
       with:
         ref: ${{ env.REF_TO_CHECKOUT }}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
  https://hyland.atlassian.net/browse/OPSEXP-3981
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [X] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Avoid failing when changes are needed in a PR. This will allow dependabot PRs to succeed when bumping versions in a dependency like a terraform module and the README needs an autoupdate.
