### PR TITLE
OPSEXP-3992 Support workflow_dispatch in github-list-changes

### DIFF
--- a/.github/actions/github-list-changes/action.yml
+++ b/.github/actions/github-list-changes/action.yml
@@ -23,4 +23,5 @@ runs:
         PULL_REQUEST_NUMBER: ${{ github.event.number }}
         WRITE_LIST_TO_ENV: ${{ inputs.write-list-to-env }}
         GH_TOKEN: ${{ inputs.github-token }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: ${{ github.action_path }}/github-list-changes.sh

--- a/.github/actions/github-list-changes/github-list-changes.sh
+++ b/.github/actions/github-list-changes/github-list-changes.sh
@@ -50,6 +50,9 @@ elif [[ $GITHUB_EVENT_NAME == "issue_comment" ]]; then
     list_pr_changes ".issue.pull_request" "issue_comment"
 elif [[ $GITHUB_EVENT_NAME == "pull_request_review" ]]; then
     list_pr_changes ".pull_request" "pull_request_review"
+elif [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+    echo "Getting the list of changed files from origin/$DEFAULT_BRANCH to HEAD"
+    git diff --name-only "origin/$DEFAULT_BRANCH" HEAD > all-changed-files.txt
 else
     echo "Unsupported event type: $GITHUB_EVENT_NAME"
     exit 1

--- a/.github/actions/github-list-changes/github-list-changes.sh
+++ b/.github/actions/github-list-changes/github-list-changes.sh
@@ -51,8 +51,12 @@ elif [[ $GITHUB_EVENT_NAME == "issue_comment" ]]; then
 elif [[ $GITHUB_EVENT_NAME == "pull_request_review" ]]; then
     list_pr_changes ".pull_request" "pull_request_review"
 elif [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+    if ! git rev-parse --verify "refs/remotes/origin/$DEFAULT_BRANCH" > /dev/null 2>&1; then
+        echo "Failed to resolve origin/$DEFAULT_BRANCH, cannot determine changed files for workflow_dispatch."
+        exit 1
+    fi
     echo "Getting the list of changed files from origin/$DEFAULT_BRANCH to HEAD"
-    git diff --name-only "origin/$DEFAULT_BRANCH" HEAD > all-changed-files.txt
+    git diff --name-only "origin/$DEFAULT_BRANCH"...HEAD > all-changed-files.txt
 else
     echo "Unsupported event type: $GITHUB_EVENT_NAME"
     exit 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Retrieve PR or last commit changes (used for auto-detection of terraform root path and/or environment)
         if: inputs.terraform_root_path == '' || inputs.terraform_env == ''
         id: last-changes-diff
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@OPSEXP-3992-list-changes-workflow-dispatch
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v17.1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Retrieve PR or last commit changes (used for auto-detection of terraform root path and/or environment)
         if: inputs.terraform_root_path == '' || inputs.terraform_env == ''
         id: last-changes-diff
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v17.1.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@OPSEXP-3992-list-changes-workflow-dispatch
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -918,8 +918,10 @@ Use this action when running a workflow which clone a private repository over ht
 
 ### github-list-changes
 
-List the changes in a pull request (`pull-request` event) or that were pushed to
-a branch (`push` event).
+List the changes in a pull request (`pull_request` event, optionally
+`issue_comment` and `pull_request_review` events if a GitHub token is provided),
+that were pushed to a branch (`push` event), or that differ from the default
+branch on a manual run (`workflow_dispatch` event).
 
 This action requires a checkout with `fetch-depth: 0` option as follows:
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-3992
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-eks-clusters/actions/runs/24347641886

### Description

Adds support for the `workflow_dispatch` event by comparing changes from `origin/$DEFAULT_BRANCH` to `HEAD`, ensuring detection of changed files when the workflow is triggered manually against a specific branch.
