### PR TITLE
OPSEXP-4002 feat: add reusable repository mirror workflow and documentation

### DIFF
--- a/.github/workflows/reusable-repository-mirror.yml
+++ b/.github/workflows/reusable-repository-mirror.yml
@@ -64,13 +64,17 @@ jobs:
       - name: Mirror branch
         env:
           GH_TOKEN: ${{ secrets.bot-token }}
+          SOURCE_REPO: ${{ matrix.source }}
+          TARGET_REPO: ${{ matrix.target }}
+          BRANCH: ${{ matrix.branch }}
+          TARGET_BRANCH: ${{ matrix.target_branch }}
         run: |
-          git clone --single-branch --branch "${{ matrix.branch }}" \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ matrix.source }}.git" \
+          git clone --single-branch --branch "${BRANCH}" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${SOURCE_REPO}.git" \
             source
           cd source
           # --force is intentional: the target is a read-only mirror and must exactly
           # match the source branch at all times.
           git push --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ matrix.target }}.git" \
-            "HEAD:refs/heads/${{ matrix.target_branch }}"
+            "https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git" \
+            "HEAD:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/reusable-repository-mirror.yml
+++ b/.github/workflows/reusable-repository-mirror.yml
@@ -1,0 +1,76 @@
+name: Mirror repositories
+
+on:
+  workflow_call:
+    inputs:
+      config-file:
+        description: "Path to the mirrored repos configuration file"
+        required: false
+        type: string
+        default: ".github/mirrored-repos.yml"
+    secrets:
+      bot-token:
+        description: "Token with read access to source repositories and write access to target repositories"
+        required: true
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set matrix data
+        id: set-matrix
+        run: |
+          # shellcheck disable=SC2016
+          echo "matrix=$(yq e '
+            [.repos[] | select(has("branches")) | . as $r | .branches[] | {
+              "source": $r.source, "target": $r.target,
+              "branch": ., "target_branch": .,
+              "name": ($r.source + " @ " + .)
+            }]
+            +
+            [.repos[] | select(has("branch")) | select(.branch | type == "!!map") | . as $r | {
+              "source": $r.source, "target": $r.target,
+              "branch": $r.branch.source, "target_branch": $r.branch.target,
+              "name": ($r.source + " @ " + $r.branch.source + " -> " + $r.branch.target)
+            }]
+          ' -o json -I=0 "${{ inputs.config-file }}")" >> "$GITHUB_OUTPUT"
+
+  mirror:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    needs: generate-matrix
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Validate secrets
+        env:
+          GH_TOKEN: ${{ secrets.bot-token }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::bot-token secret is not available. Please provide a token with read access to source repositories and write access to target repositories."
+            exit 1
+          fi
+
+      - name: Mirror branch
+        env:
+          GH_TOKEN: ${{ secrets.bot-token }}
+        run: |
+          git clone --single-branch --branch "${{ matrix.branch }}" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ matrix.source }}.git" \
+            source
+          cd source
+          # --force is intentional: the target is a read-only mirror and must exactly
+          # match the source branch at all times.
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ matrix.target }}.git" \
+            "HEAD:refs/heads/${{ matrix.target_branch }}"

--- a/.github/workflows/reusable-repository-mirror.yml
+++ b/.github/workflows/reusable-repository-mirror.yml
@@ -7,7 +7,6 @@ on:
         description: "Path to the mirrored repos configuration file"
         required: false
         type: string
-        default: ".github/mirrored-repos.yml"
     secrets:
       bot-token:
         description: "Token with read access to source repositories and write access to target repositories"

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@ Here follows the list of GitHub Actions topics available in the current document
 - [Reusable workflows provided by us](#reusable-workflows-provided-by-us)
   - [branch-promotion-prs](#branch-promotion-prs)
   - [helm-publish-new-package-version](#helm-publish-new-package-version)
+  - [repository-mirror](#repository-mirror)
   - [reusable-release](#reusable-release)
   - [terraform](#terraform)
 - [Cookbook](#cookbook)
@@ -2554,6 +2555,54 @@ Calculates the new alpha version, creates new git tag and publishes the new pack
       helm-charts-repo-branch: gh-pages
     secrets: inherit
 ```
+
+### repository-mirror
+
+Force-pushes specific branches from source repositories to separate target
+(mirror) repositories, keeping them in sync.
+
+The list of repositories and branches to mirror is declared in a configuration
+file in the caller repository (e.g. `.github/mirrored-repos.yml`). Each entry
+supports two forms.
+
+**Multiple branches (no rename)** — use the `branches` list; the branch name is
+preserved as-is in the target repository:
+
+```yaml
+repos:
+  - source: Alfresco/alfresco-community-repo
+    target: Alfresco/alfresco-community-repo-25.N
+    branches:
+      - release/25.N
+      - release/25.1
+```
+
+**Single branch rename** — use the `branch` key (singular) with a `{source,
+target}` mapping to push to a different branch name in the mirror:
+
+```yaml
+repos:
+  # rename — push release/25.N as "main" in the target
+  - source: Alfresco/alfresco-community-repo
+    target: Alfresco/alfresco-community-repo-25.N
+    branch:
+      source: release/25.N
+      target: main
+```
+
+```yaml
+jobs:
+  mirror:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/reusable-repository-mirror.yml@v17.3.0
+    with:
+      config-file: .github/mirrored-repos.yml
+    secrets:
+      bot-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+```
+
+To add a new mirror, append an entry to your configuration file following one of
+the forms above. The `bot-token` secret must have **read access to the source
+repositories** and **write access to the target repositories**.
 
 ### reusable-release
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4002
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/alfresco-security-testing/pull/644

### Description

<!-- Explain your changes -->

This pull request introduces a new reusable GitHub Actions workflow for mirroring branches between repositories, along with supporting documentation updates. The workflow allows teams to keep branches in target repositories perfectly in sync with source repositories, supporting both direct branch mirroring and branch renaming. Documentation has been updated to describe the new workflow and how to configure it.

**New repository mirroring workflow:**

* Added `.github/workflows/reusable-repository-mirror.yml`, a reusable workflow that force-pushes specified branches from source repositories to target (mirror) repositories, supporting both multiple branches and single branch renames as configured in a YAML file.

**Documentation updates:**

* Updated `docs/README.md` to add `repository-mirror` to the list of reusable workflows and provide detailed usage instructions, including configuration examples and requirements for the `bot-token` secret. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R131) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R2559-R2606)
