### PR TITLE
OPSEXP-4023 Add azure auth for reusable terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,6 +58,8 @@ on:
         required: false
       RANCHER2_SECRET_KEY:
         required: false
+      AZURE_CREDENTIALS:
+        required: false
       CUSTOM_SECRET_0:
         required: false
       CUSTOM_SECRET_1:
@@ -295,6 +297,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RANCHER2_ACCESS_KEY: ${{ secrets.RANCHER2_ACCESS_KEY }}
       RANCHER2_SECRET_KEY: ${{ secrets.RANCHER2_SECRET_KEY }}
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       CUSTOM_SECRET_0: ${{ secrets.CUSTOM_SECRET_0 }}
       CUSTOM_SECRET_1: ${{ secrets.CUSTOM_SECRET_1 }}
       CUSTOM_SECRET_2: ${{ secrets.CUSTOM_SECRET_2 }}
@@ -389,9 +392,15 @@ jobs:
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         if: vars.AWS_ROLE_ARN != ''
         with:
-          aws-region: ${{ env.AWS_DEFAULT_REGION}}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           role-session-name: TerraformWorkflow
+
+      - name: Configure Azure Credentials
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        if: env.AZURE_CREDENTIALS != ''
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Load environment variables from yml
         uses: Alfresco/alfresco-build-tools/.github/actions/env-load-from-yaml@v17.6.1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -43,11 +43,11 @@ on:
         required: false
         default: ''
       github_app_repo_owner:
-        description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same organization or another one where the GitHub App is installed.
+        description: the owner (organization) of the GitHub App used to generate a token for accessing the private 'terraform-alfresco-modules' repository. Requires github_app_token_client_id and GITHUB_TOKEN_PRIVATE_KEY to be set.
         type: string
         required: false
       github_app_token_client_id:
-        description: the client ID of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Requires github_app_repo_owner and GITHUB_TOKEN_PRIVATE_KEY to be set.
+        description: the client ID of the GitHub App used to generate a token for accessing the private 'terraform-alfresco-modules' repository. Requires github_app_repo_owner and GITHUB_TOKEN_PRIVATE_KEY to be set.
         type: string
         required: false
     secrets:
@@ -381,6 +381,10 @@ jobs:
           fi
           if [ -z "${{ vars.TERRAFORM_STATE_BUCKET }}" ] && [ -z "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
             echo "Either TERRAFORM_STATE_BUCKET (for AWS S3) or TERRAFORM_STATE_STORAGE_ACCOUNT (for Azure Storage) must be set in the vars context of $ENVIRONMENT_NAME to specify the backend used for terraform state storage"
+            exit 1
+          fi
+          if [ -n "${{ vars.TERRAFORM_STATE_BUCKET }}" ] && [ -n "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
+            echo "TERRAFORM_STATE_BUCKET and TERRAFORM_STATE_STORAGE_ACCOUNT are mutually exclusive in the vars context of $ENVIRONMENT_NAME; configure exactly one terraform state backend"
             exit 1
           fi
           if [ -n "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,6 +58,8 @@ on:
       BOT_GITHUB_TOKEN:
         description: a GitHub token used to fetch terraform modules from private GitHub repositories.
         required: false
+      TERRAFORM_HTTP_CREDENTIALS:
+        required: false
       DOCKER_USERNAME:
         required: false
       DOCKER_PASSWORD:
@@ -318,8 +320,7 @@ jobs:
       CUSTOM_SECRET_9: ${{ secrets.CUSTOM_SECRET_9 }}
       RESOURCE_NAME: ${{ vars.RESOURCE_NAME }}
       TF_VAR_resource_name: ${{ vars.RESOURCE_NAME }}
-      TERRAFORM_HTTP_CREDENTIALS: |
-        github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}
+      TERRAFORM_HTTP_CREDENTIALS: ${{ secrets.TERRAFORM_HTTP_CREDENTIALS }}
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -326,7 +326,11 @@ jobs:
           CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
           CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
           TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
+          SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
           az login --service-principal -u "$CLIENT_ID" -p "$CLIENT_SECRET" --tenant "$TENANT_ID" --output none
+          if [ -n "$SUBSCRIPTION_ID" ] && [ "$SUBSCRIPTION_ID" != "null" ]; then
+            az account set --subscription "$SUBSCRIPTION_ID"
+          fi
         fi
         if [ ! -x ./aws/install ]; then
           curl -sSf https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -318,8 +318,6 @@ jobs:
       CUSTOM_SECRET_9: ${{ secrets.CUSTOM_SECRET_9 }}
       RESOURCE_NAME: ${{ vars.RESOURCE_NAME }}
       TF_VAR_resource_name: ${{ vars.RESOURCE_NAME }}
-      TERRAFORM_HTTP_CREDENTIALS: |
-        github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then
@@ -400,6 +398,7 @@ jobs:
           TERRAFORM_ROOT_PATH: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}
         run: |
           if [ -n "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
+            echo "Using Azure Storage backend: ${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}/${{ vars.TERRAFORM_STATE_CONTAINER }}"
             {
               echo "backend_config<<BACKEND"
               echo "resource_group_name=${{ vars.TERRAFORM_STATE_RESOURCE_GROUP }}"
@@ -410,6 +409,7 @@ jobs:
               echo "BACKEND"
             } >> "$GITHUB_OUTPUT"
           else
+            echo "Using AWS S3 backend: ${{ vars.TERRAFORM_STATE_BUCKET }}"
             {
               echo "backend_config<<BACKEND"
               echo "bucket=${{ vars.TERRAFORM_STATE_BUCKET }}"
@@ -462,10 +462,16 @@ jobs:
           client-id: ${{ secrets.GITHUB_TOKEN_CLIENT_ID }}
           private-key: ${{ secrets.GITHUB_TOKEN_PRIVATE_KEY }}
           owner: ${{ inputs.github-app-repo-owner }}
+          repositories: |
+            terraform-alfresco-modules
 
-      - name: Override TERRAFORM_HTTP_CREDENTIALS with GitHub App token
-        if: steps.app-token.outputs.token != ''
-        run: echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+      - name: Set TERRAFORM_HTTP_CREDENTIALS
+        run: |
+          if [ -n "${{ steps.app-token.outputs.token }}" ]; then
+            echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          elif [ -n "${{ secrets.BOT_GITHUB_TOKEN }}" ]; then
+            echo "TERRAFORM_HTTP_CREDENTIALS=github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Terraform validate
         if: needs.compute_basic_vars.outputs.terraform_operation == 'plan' && github.run_attempt == 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -323,7 +323,7 @@ jobs:
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then
-          curl -skL https://aka.ms/InstallAzureCLIDeb | bash
+          curl -sL https://aka.ms/InstallAzureCLIDeb | bash
           CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
           CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
           TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
@@ -390,6 +390,16 @@ jobs:
             fi
             if [ -z "${{ vars.TERRAFORM_STATE_CONTAINER }}" ]; then
               echo "TERRAFORM_STATE_CONTAINER must be set in the vars context of $ENVIRONMENT_NAME when using Azure Storage backend"
+              exit 1
+            fi
+            if [ -z "${{ secrets.AZURE_CREDENTIALS }}" ]; then
+              echo "AZURE_CREDENTIALS secret must be provided when using Azure Storage backend"
+              exit 1
+            fi
+          fi
+          if [ -n "${{ inputs.github_app_repo_owner }}" ]; then
+            if [ -z "${{ inputs.github_app_token_client_id }}" ] || [ -z "${{ secrets.GITHUB_TOKEN_PRIVATE_KEY }}" ]; then
+              echo "github_app_token_client_id input and GITHUB_TOKEN_PRIVATE_KEY secret must both be provided when github_app_repo_owner is set"
               exit 1
             fi
           fi

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -54,8 +54,6 @@ on:
       BOT_GITHUB_TOKEN:
         description: a GitHub token used to fetch terraform modules from private GitHub repositories.
         required: false
-      TERRAFORM_HTTP_CREDENTIALS:
-        required: false
       DOCKER_USERNAME:
         required: false
       DOCKER_PASSWORD:
@@ -90,6 +88,7 @@ on:
         required: false
       GITHUB_TOKEN_PRIVATE_KEY:
         required: false
+
 jobs:
   compute_basic_vars:
     name: compute basic variables
@@ -319,6 +318,8 @@ jobs:
       CUSTOM_SECRET_9: ${{ secrets.CUSTOM_SECRET_9 }}
       RESOURCE_NAME: ${{ vars.RESOURCE_NAME }}
       TF_VAR_resource_name: ${{ vars.RESOURCE_NAME }}
+      TERRAFORM_HTTP_CREDENTIALS: |
+        github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then
@@ -460,6 +461,7 @@ jobs:
           yml_path: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/tfenv.yml
 
       - name: Generate GitHub App token
+        if: inputs.github-app-repo-owner != ''
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
@@ -467,8 +469,8 @@ jobs:
           private-key: ${{ secrets.GITHUB_TOKEN_PRIVATE_KEY }}
           owner: ${{ inputs.github-app-repo-owner }}
 
-      - name: Set TERRAFORM_HTTP_CREDENTIALS for fetching private modules
-        if: steps.app-token.outputs.token
+      - name: Override TERRAFORM_HTTP_CREDENTIALS with GitHub App token
+        if: steps.app-token.outputs.token != ''
         run: echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Terraform validate

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -405,7 +405,6 @@ jobs:
               echo "storage_account_name=${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}"
               echo "container_name=${{ vars.TERRAFORM_STATE_CONTAINER }}"
               echo "key=${{ vars.RESOURCE_NAME }}/${{ env.TERRAFORM_ROOT_PATH }}/terraform.tfstate"
-              echo "use_azuread_auth=true"
               echo "use_cli=true"
               echo "BACKEND"
             } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -449,12 +449,6 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           role-session-name: TerraformWorkflow
 
-      - name: Configure Azure Credentials
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        if: env.AZURE_CREDENTIALS != ''
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Load environment variables from yml
         uses: Alfresco/alfresco-build-tools/.github/actions/env-load-from-yaml@v17.6.1
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,8 +42,12 @@ on:
         type: string
         required: false
         default: ''
-      github-app-repo-owner:
+      github_app_repo_owner:
         description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same organization or another one where the GitHub App is installed.
+        type: string
+        required: false
+      github_app_token_client_id:
+        description: the client ID of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Requires github_app_repo_owner and GITHUB_TOKEN_PRIVATE_KEY to be set.
         type: string
         required: false
     secrets:
@@ -83,8 +87,6 @@ on:
       CUSTOM_SECRET_8:
         required: false
       CUSTOM_SECRET_9:
-        required: false
-      GITHUB_TOKEN_CLIENT_ID:
         required: false
       GITHUB_TOKEN_PRIVATE_KEY:
         required: false
@@ -455,20 +457,20 @@ jobs:
           yml_path: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/tfenv.yml
 
       - name: Generate GitHub App token
-        if: inputs.github-app-repo-owner != ''
+        if: inputs.github_app_repo_owner != ''
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ secrets.GITHUB_TOKEN_CLIENT_ID }}
+          client-id: ${{ inputs.github_app_token_client_id }}
           private-key: ${{ secrets.GITHUB_TOKEN_PRIVATE_KEY }}
-          owner: ${{ inputs.github-app-repo-owner }}
+          owner: ${{ inputs.github_app_repo_owner }}
           repositories: |
             terraform-alfresco-modules
 
       - name: Set TERRAFORM_HTTP_CREDENTIALS
         run: |
           if [ -n "${{ steps.app-token.outputs.token }}" ]; then
-            echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+            echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github_app_repo_owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
           elif [ -n "${{ secrets.BOT_GITHUB_TOKEN }}" ]; then
             echo "TERRAFORM_HTTP_CREDENTIALS=github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,14 +42,6 @@ on:
         type: string
         required: false
         default: ''
-      backend_config:
-        description: |
-          Custom backend configuration for Terraform (e.g. for azurerm backend).
-          When provided, this overrides the default S3 backend config.
-          Format: key=value pairs, one per line.
-        type: string
-        required: false
-        default: ''
       github-app-repo-owner:
         description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same repository or another one where the GitHub App is installed.
         type: string
@@ -331,6 +323,10 @@ jobs:
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then
           curl -skL https://aka.ms/InstallAzureCLIDeb | bash
+          CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
+          CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
+          TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
+          az login --service-principal -u "$CLIENT_ID" -p "$CLIENT_SECRET" --tenant "$TENANT_ID" --output none
         fi
         if [ ! -x ./aws/install ]; then
           curl -sSf https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
@@ -378,21 +374,35 @@ jobs:
             echo "RESOURCE_NAME must be set in the vars context of $ENVIRONMENT_NAME to provide a unique identifier"
             exit 1
           fi
-          if [ -z "${{ inputs.backend_config }}" ] && [ -z "${{ vars.TERRAFORM_STATE_BUCKET }}" ]; then
-            echo "TERRAFORM_STATE_BUCKET must be set in the vars context of $ENVIRONMENT_NAME to specify the S3 bucket used for terraform state storage (or provide a custom backend_config input)"
+          if [ -z "${{ vars.TERRAFORM_STATE_BUCKET }}" ] && [ -z "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
+            echo "Either TERRAFORM_STATE_BUCKET (for AWS S3) or TERRAFORM_STATE_STORAGE_ACCOUNT (for Azure Storage) must be set in the vars context of $ENVIRONMENT_NAME to specify the backend used for terraform state storage"
             exit 1
+          fi
+          if [ -n "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
+            if [ -z "${{ vars.TERRAFORM_STATE_RESOURCE_GROUP }}" ]; then
+              echo "TERRAFORM_STATE_RESOURCE_GROUP must be set in the vars context of $ENVIRONMENT_NAME when using Azure Storage backend"
+              exit 1
+            fi
+            if [ -z "${{ vars.TERRAFORM_STATE_CONTAINER }}" ]; then
+              echo "TERRAFORM_STATE_CONTAINER must be set in the vars context of $ENVIRONMENT_NAME when using Azure Storage backend"
+              exit 1
+            fi
           fi
 
       - name: Build backend config
         id: backend-config
         env:
           TERRAFORM_ROOT_PATH: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}
-          CUSTOM_BACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
-          if [ -n "$CUSTOM_BACKEND_CONFIG" ]; then
+          if [ -n "${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}" ]; then
             {
               echo "backend_config<<BACKEND"
-              echo "${{ env.CUSTOM_BACKEND_CONFIG }}"
+              echo "resource_group_name=${{ vars.TERRAFORM_STATE_RESOURCE_GROUP }}"
+              echo "storage_account_name=${{ vars.TERRAFORM_STATE_STORAGE_ACCOUNT }}"
+              echo "container_name=${{ vars.TERRAFORM_STATE_CONTAINER }}"
+              echo "key=${{ vars.RESOURCE_NAME }}/${{ env.TERRAFORM_ROOT_PATH }}/terraform.tfstate"
+              echo "use_azuread_auth=true"
+              echo "use_cli=true"
               echo "BACKEND"
             } >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Set TERRAFORM_HTTP_CREDENTIALS for fetching private modules
         if: steps.app-token.outputs.token
-        run: echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token::${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+        run: echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token:${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Terraform validate
         if: needs.compute_basic_vars.outputs.terraform_operation == 'plan' && github.run_attempt == 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -43,7 +43,7 @@ on:
         required: false
         default: ''
       github-app-repo-owner:
-        description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same repository or another one where the GitHub App is installed.
+        description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same organization or another one where the GitHub App is installed.
         type: string
         required: false
     secrets:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -333,11 +333,13 @@ jobs:
             az account set --subscription "$SUBSCRIPTION_ID"
           fi
         fi
-        if [ ! -x ./aws/install ]; then
-          curl -sSf https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
-          unzip -q awscliv2.zip
+        if [ -n "$AWS_ACCESS_KEY_ID" ] || [ -n "${{ vars.AWS_ROLE_ARN }}" ]; then
+          if [ ! -x ./aws/install ]; then
+            curl -sSf https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
+            unzip -q awscliv2.zip
+          fi
+          ./aws/install
         fi
-        ./aws/install
         if [ "${{ inputs.install_kubectl }}" == "true" ]; then
           if [ -z "${{ inputs.kubectl_version }}" ]; then
             echo "⚙️ Will install latest stable kubectl..."

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,6 +50,10 @@ on:
         type: string
         required: false
         default: ''
+      github-app-repo-owner:
+        description: the owner of the GitHub App used to generate a token for accessing private repositories (if needed for fetching terraform modules or other resources). Can be the same repository or another one where the GitHub App is installed.
+        type: string
+        required: false
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false
@@ -90,7 +94,10 @@ on:
         required: false
       CUSTOM_SECRET_9:
         required: false
-
+      GITHUB_TOKEN_CLIENT_ID:
+        required: false
+      GITHUB_TOKEN_PRIVATE_KEY:
+        required: false
 jobs:
   compute_basic_vars:
     name: compute basic variables
@@ -320,7 +327,6 @@ jobs:
       CUSTOM_SECRET_9: ${{ secrets.CUSTOM_SECRET_9 }}
       RESOURCE_NAME: ${{ vars.RESOURCE_NAME }}
       TF_VAR_resource_name: ${{ vars.RESOURCE_NAME }}
-      TERRAFORM_HTTP_CREDENTIALS: ${{ secrets.TERRAFORM_HTTP_CREDENTIALS }}
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
         if [ -n "$AZURE_CREDENTIALS" ]; then
@@ -439,6 +445,18 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/env-load-from-yaml@v17.6.1
         with:
           yml_path: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/tfenv.yml
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GITHUB_TOKEN_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_TOKEN_PRIVATE_KEY }}
+          owner: ${{ inputs.github-app-repo-owner }}
+
+      - name: Set TERRAFORM_HTTP_CREDENTIALS for fetching private modules
+        if: steps.app-token.outputs.token
+        run: echo "TERRAFORM_HTTP_CREDENTIALS=github.com/${{ inputs.github-app-repo-owner }}=x-access-token::${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Terraform validate
         if: needs.compute_basic_vars.outputs.terraform_operation == 'plan' && github.run_attempt == 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,6 +42,14 @@ on:
         type: string
         required: false
         default: ''
+      backend_config:
+        description: |
+          Custom backend configuration for Terraform (e.g. for azurerm backend).
+          When provided, this overrides the default S3 backend config.
+          Format: key=value pairs, one per line.
+        type: string
+        required: false
+        default: ''
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false
@@ -314,6 +322,9 @@ jobs:
         github.com/Alfresco=alfresco-build:${{ secrets.BOT_GITHUB_TOKEN }}
       TERRAFORM_PRE_RUN: |
         set +x -euo pipefail
+        if [ -n "$AZURE_CREDENTIALS" ]; then
+          curl -skL https://aka.ms/InstallAzureCLIDeb | bash
+        fi
         if [ ! -x ./aws/install ]; then
           curl -sSf https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
           unzip -q awscliv2.zip
@@ -360,9 +371,30 @@ jobs:
             echo "RESOURCE_NAME must be set in the vars context of $ENVIRONMENT_NAME to provide a unique identifier"
             exit 1
           fi
-          if [ -z "${{ vars.TERRAFORM_STATE_BUCKET }}" ]; then
-            echo "TERRAFORM_STATE_BUCKET must be set in the vars context of $ENVIRONMENT_NAME to specify the S3 bucket used for terraform state storage"
+          if [ -z "${{ inputs.backend_config }}" ] && [ -z "${{ vars.TERRAFORM_STATE_BUCKET }}" ]; then
+            echo "TERRAFORM_STATE_BUCKET must be set in the vars context of $ENVIRONMENT_NAME to specify the S3 bucket used for terraform state storage (or provide a custom backend_config input)"
             exit 1
+          fi
+
+      - name: Build backend config
+        id: backend-config
+        env:
+          TERRAFORM_ROOT_PATH: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}
+          CUSTOM_BACKEND_CONFIG: ${{ inputs.backend_config }}
+        run: |
+          if [ -n "$CUSTOM_BACKEND_CONFIG" ]; then
+            {
+              echo "backend_config<<BACKEND"
+              echo "${{ env.CUSTOM_BACKEND_CONFIG }}"
+              echo "BACKEND"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "backend_config<<BACKEND"
+              echo "bucket=${{ vars.TERRAFORM_STATE_BUCKET }}"
+              echo "key=${{ vars.RESOURCE_NAME }}/${{ env.TERRAFORM_ROOT_PATH }}/terraform.tfstate"
+              echo "BACKEND"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
@@ -412,9 +444,7 @@ jobs:
         uses: dflook/terraform-validate@4cef5d8a4b92bcd88486e41e22a42942a382c9d6 # v2.2.3
         with:
           path: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}
-          backend_config: |
-            bucket=${{ vars.TERRAFORM_STATE_BUCKET }}
-            key=${{ vars.RESOURCE_NAME }}/${{ needs.compute_basic_vars.outputs.terraform_root_path }}/terraform.tfstate
+          backend_config: ${{ steps.backend-config.outputs.backend_config }}
 
       - name: Terraform plan
         uses: dflook/terraform-plan@7878bff63e2099cdc9be9a6f33cbbbf687f8f0fe # v2.2.3
@@ -425,9 +455,7 @@ jobs:
           var_file: |
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}common.tfvars
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}${{ needs.compute_basic_vars.outputs.environment_name }}.tfvars
-          backend_config: |
-            bucket=${{ vars.TERRAFORM_STATE_BUCKET }}
-            key=${{ vars.RESOURCE_NAME }}/${{ needs.compute_basic_vars.outputs.terraform_root_path }}/terraform.tfstate
+          backend_config: ${{ steps.backend-config.outputs.backend_config }}
 
       - name: Terraform apply
         uses: dflook/terraform-apply@5489b988934a50bf1489d5b7c5253b46520a7dca # v2.2.3
@@ -439,9 +467,7 @@ jobs:
           var_file: |
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}common.tfvars
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}${{ needs.compute_basic_vars.outputs.environment_name }}.tfvars
-          backend_config: |
-            bucket=${{ vars.TERRAFORM_STATE_BUCKET }}
-            key=${{ vars.RESOURCE_NAME }}/${{ needs.compute_basic_vars.outputs.terraform_root_path }}/terraform.tfstate
+          backend_config: ${{ steps.backend-config.outputs.backend_config }}
 
       - name: Terraform destroy
         uses: dflook/terraform-destroy@b198834c4a4dd959f26649f2a9d24c59e9c9f205 # v2.2.3
@@ -451,6 +477,4 @@ jobs:
           var_file: |
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}common.tfvars
             ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/${{ inputs.tfvars_subfolder && format('{0}/', inputs.tfvars_subfolder) || '' }}${{ needs.compute_basic_vars.outputs.environment_name }}.tfvars
-          backend_config: |
-            bucket=${{ vars.TERRAFORM_STATE_BUCKET }}
-            key=${{ vars.RESOURCE_NAME }}/${{ needs.compute_basic_vars.outputs.terraform_root_path }}/terraform.tfstate
+          backend_config: ${{ steps.backend-config.outputs.backend_config }}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -120,13 +120,10 @@ The following GitHub secrets (all optional) are also accepted by this workflow:
 - `AZURE_CREDENTIALS`: (required for Azure) JSON object containing Azure service
   principal credentials (`clientId`, `clientSecret`, `subscriptionId`, `tenantId`)
 - `BOT_GITHUB_TOKEN`: (optional) token to access private terraform modules in the
-  Alfresco org. Used as a fallback when `github-app-repo-owner` is not set.
-- `GITHUB_TOKEN_CLIENT_ID`: (optional) client ID of a GitHub App used to generate
-  a token for accessing private terraform modules. Requires `github-app-repo-owner`
-  input and `GITHUB_TOKEN_PRIVATE_KEY` secret to be provided.
+  Alfresco org. Used as a fallback when `github_app_repo_owner` is not set.
 - `GITHUB_TOKEN_PRIVATE_KEY`: (optional) private key of the GitHub App used to
   generate a token for accessing private terraform modules. Requires
-  `github-app-repo-owner` input and `GITHUB_TOKEN_CLIENT_ID` secret to be set.
+  `github-app-repo-owner` input and `github_app_repo_owner` input to be set.
 - `DOCKER_USERNAME` (optional): Docker Hub credentials
 - `DOCKER_PASSWORD` (optional): Docker Hub credentials
 - `RANCHER2_ACCESS_KEY` (optional): access key to use the rancher terraform

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -100,10 +100,10 @@ variables:
 - `TERRAFORM_STATE_CONTAINER`: the name of the blob container within the storage
   account
 
-The backend configuration is automatically constructed with
-`use_azuread_auth=true` and `use_cli=true`, which means the `AZURE_CREDENTIALS`
-secret must be provided to authenticate via Azure CLI. The state file key is
-built using the pattern `<RESOURCE_NAME>/<terraform_root_path>/terraform.tfstate`.
+The backend configuration is automatically constructed with `use_cli=true`,
+which means the `AZURE_CREDENTIALS` secret must be provided to authenticate via
+Azure CLI. The state file key is built using the pattern
+`<RESOURCE_NAME>/<terraform_root_path>/terraform.tfstate`.
 
 Your Terraform code should declare the `azurerm` backend:
 
@@ -118,7 +118,7 @@ The following GitHub secrets (all optional) are also accepted by this workflow:
 - `AWS_ACCESS_KEY_ID`: (optional when using OIDC) access key to use the AWS terraform provider
 - `AWS_SECRET_ACCESS_KEY`: (optional when using OIDC) secret key to use the AWS terraform provider
 - `AZURE_CREDENTIALS`: (required for Azure) JSON object containing Azure service
-  principal credentials (`clientId`, `clientSecret`, `tenantId`)
+  principal credentials (`clientId`, `clientSecret`, `subscriptionId`, `tenantId`)
 - `BOT_GITHUB_TOKEN` (to access private terraform modules in the Alfresco org)
 - `DOCKER_USERNAME` (optional): Docker Hub credentials
 - `DOCKER_PASSWORD` (optional): Docker Hub credentials

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -60,15 +60,20 @@ etc.).
 GitHub Environments must be configured with the following GitHub variables
 (repository or environment):
 
+- `RESOURCE_NAME`: used to namespace every resource created, e.g. State file in
+  the storage backend. You can use it as well inside Terraform by defining a
+  variable `resource_name` in your Terraform code.
+
+#### AWS S3 backend
+
+When using AWS S3 as the Terraform state backend, set the following variables:
+
 - `AWS_DEFAULT_REGION`: where the AWS resources will be created
 - `AWS_ROLE_ARN` (optional): the ARN of the role to assume in case OIDC
   authentication is available
-- `RESOURCE_NAME`: used to namespace every resource created, e.g. State file in
-  the S3 bucket. You can use it as well inside Terraform by defining a variable
-  `resource_name` in your Terraform code.
-- `TERRAFORM_STATE_BUCKET`: the name of the S3 bucket where to store the terraform
-  state. You can reuse the same bucket for multiple environments as long as you
-  provide a different `RESOURCE_NAME` for each environment.
+- `TERRAFORM_STATE_BUCKET`: the name of the S3 bucket where to store the
+  terraform state. You can reuse the same bucket for multiple environments as
+  long as you provide a different `RESOURCE_NAME` for each environment.
 
 Alternatively to providing `AWS_ROLE_ARN` as GitHub variable, you can set
 `create_oidc_token_file` input to `true` to request an AWS OIDC token which will
@@ -83,12 +88,37 @@ backend "s3" {
 }
 ```
 
+#### Azure Storage backend
+
+When using Azure Storage as the Terraform state backend, set the following
+variables:
+
+- `TERRAFORM_STATE_RESOURCE_GROUP`: the name of the Azure resource group
+  containing the storage account
+- `TERRAFORM_STATE_STORAGE_ACCOUNT`: the name of the Azure storage account where
+  to store the terraform state
+- `TERRAFORM_STATE_CONTAINER`: the name of the blob container within the storage
+  account
+
+The backend configuration is automatically constructed with
+`use_azuread_auth=true` and `use_cli=true`, which means the `AZURE_CREDENTIALS`
+secret must be provided to authenticate via Azure CLI. The state file key is
+built using the pattern `<RESOURCE_NAME>/<terraform_root_path>/terraform.tfstate`.
+
+Your Terraform code should declare the `azurerm` backend:
+
+```tf
+backend "azurerm" {}
+```
+
 ### GitHub Secrets
 
 The following GitHub secrets (all optional) are also accepted by this workflow:
 
 - `AWS_ACCESS_KEY_ID`: (optional when using OIDC) access key to use the AWS terraform provider
 - `AWS_SECRET_ACCESS_KEY`: (optional when using OIDC) secret key to use the AWS terraform provider
+- `AZURE_CREDENTIALS`: (required for Azure) JSON object containing Azure service
+  principal credentials (`clientId`, `clientSecret`, `tenantId`)
 - `BOT_GITHUB_TOKEN` (to access private terraform modules in the Alfresco org)
 - `DOCKER_USERNAME` (optional): Docker Hub credentials
 - `DOCKER_PASSWORD` (optional): Docker Hub credentials

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -113,7 +113,8 @@ backend "azurerm" {}
 
 ### GitHub Secrets
 
-The following GitHub secrets (all optional) are also accepted by this workflow:
+The following GitHub secrets are accepted by this workflow. Most are optional,
+but some are required depending on the selected backend or authentication mode:
 
 - `AWS_ACCESS_KEY_ID`: (optional when using OIDC) access key to use the AWS terraform provider
 - `AWS_SECRET_ACCESS_KEY`: (optional when using OIDC) secret key to use the AWS terraform provider

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -123,7 +123,7 @@ The following GitHub secrets (all optional) are also accepted by this workflow:
   Alfresco org. Used as a fallback when `github-app-repo-owner` is not set.
 - `GITHUB_TOKEN_CLIENT_ID`: (optional) client ID of a GitHub App used to generate
   a token for accessing private terraform modules. Requires `github-app-repo-owner`
-  input and `GITHUB_TOKEN_PRIVATE_KEY` secret to be set.
+  input and `GITHUB_TOKEN_PRIVATE_KEY` secret to be provided.
 - `GITHUB_TOKEN_PRIVATE_KEY`: (optional) private key of the GitHub App used to
   generate a token for accessing private terraform modules. Requires
   `github-app-repo-owner` input and `GITHUB_TOKEN_CLIENT_ID` secret to be set.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -314,6 +314,20 @@ jobs:
       CUSTOM_SECRET_2: ${{ secrets.GITHUB_APP_PEM_FILE }}
       # ...
       # CUSTOM_SECRET_9: ${{ secrets.MY_CUSTOM_SECRET }}
+
+  # Azure Storage backend with GitHub App token for private terraform modules
+  invoke-terraform-aks:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/terraform.yml@v17.6.1
+    with:
+      terraform_root_path: infra
+      terraform_default_env: develop
+      terraform_operation: ${{ inputs.terraform_operation }}
+      tfvars_subfolder: envs
+      github_app_repo_owner: Alfresco
+      github_app_token_client_id: ${{ vars.MY_GITHUB_APP_CLIENT_ID }}
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      GITHUB_TOKEN_PRIVATE_KEY: ${{ secrets.MY_GITHUB_APP_PRIVATE_KEY }}
 ```
 
 ### kubectl support

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -119,7 +119,14 @@ The following GitHub secrets (all optional) are also accepted by this workflow:
 - `AWS_SECRET_ACCESS_KEY`: (optional when using OIDC) secret key to use the AWS terraform provider
 - `AZURE_CREDENTIALS`: (required for Azure) JSON object containing Azure service
   principal credentials (`clientId`, `clientSecret`, `subscriptionId`, `tenantId`)
-- `BOT_GITHUB_TOKEN` (to access private terraform modules in the Alfresco org)
+- `BOT_GITHUB_TOKEN`: (optional) token to access private terraform modules in the
+  Alfresco org. Used as a fallback when `github-app-repo-owner` is not set.
+- `GITHUB_TOKEN_CLIENT_ID`: (optional) client ID of a GitHub App used to generate
+  a token for accessing private terraform modules. Requires `github-app-repo-owner`
+  input and `GITHUB_TOKEN_PRIVATE_KEY` secret to be set.
+- `GITHUB_TOKEN_PRIVATE_KEY`: (optional) private key of the GitHub App used to
+  generate a token for accessing private terraform modules. Requires
+  `github-app-repo-owner` input and `GITHUB_TOKEN_CLIENT_ID` secret to be set.
 - `DOCKER_USERNAME` (optional): Docker Hub credentials
 - `DOCKER_PASSWORD` (optional): Docker Hub credentials
 - `RANCHER2_ACCESS_KEY` (optional): access key to use the rancher terraform

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -123,7 +123,7 @@ The following GitHub secrets (all optional) are also accepted by this workflow:
   Alfresco org. Used as a fallback when `github_app_repo_owner` is not set.
 - `GITHUB_TOKEN_PRIVATE_KEY`: (optional) private key of the GitHub App used to
   generate a token for accessing private terraform modules. Requires
-  `github-app-repo-owner` input and `github_app_repo_owner` input to be set.
+  `github_app_repo_owner` input and `github_app_token_client_id` input to be set.
 - `DOCKER_USERNAME` (optional): Docker Hub credentials
 - `DOCKER_PASSWORD` (optional): Docker Hub credentials
 - `RANCHER2_ACCESS_KEY` (optional): access key to use the rancher terraform


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4023
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: 
https://github.com/Alfresco/terraform-eks-clusters/pull/232
https://github.com/nuxeo/terraform-aks-clusters/pull/1

### Description

Enhances the `terraform.yml` GitHub Actions workflow to support Azure Storage as a Terraform state backend in addition to AWS S3, and introduces improved authentication options for accessing private Terraform modules leveraging GitHub Apps.