### PR TITLE
ci: SHA-pin internal action refs via two-pass release approach

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -223,13 +223,13 @@ pre-commit run --all-files
 cd .github/actions/action-name && bats tests/
 
 # Find all internal action references (should use SHA pins, not version tags)
-grep -r "Alfresco/alfresco-build-tools/.github" .github/
+grep -r "Alfresco/alfresco-build-tools/.github" .github/ --include="*.yml"
 
 # Check for forbidden version tags in internal references (should return no results)
-grep -r "Alfresco/alfresco-build-tools/.github.*@v[0-9]" .github/
+grep -r "Alfresco/alfresco-build-tools/.github.*@v[0-9]" .github/ --include="*.yml"
 
 # Find all SHA-pinned internal references (the correct format)
-grep -r "alfresco-build-tools.*@[0-9a-f]\{40\}" .github/
+grep -r "alfresco-build-tools.*@[0-9a-f]\{40\}" .github/ --include="*.yml"
 
 # Check for undocumented actions
 diff <(ls .github/actions) <(grep -o "### [^#]*" docs/README.md | sed 's/### //')

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ Additional notes or configuration details.
 - **MUST** use SHA pins: `Alfresco/alfresco-build-tools/.github/actions/action-name@<40-char-sha>`
 - **NEVER** use version tags: `Alfresco/alfresco-build-tools/.github/actions/action-name@v17.7.0`
 - SHA pins are managed **automatically by the release process** — do not set them manually
-- The release workflow creates an empty commit, captures its SHA, and updates all internal refs to that SHA
+- The release workflow creates a release candidate commit (SHA_RC) from the current HEAD, then the final release commit pins refs to SHA_RC — growing consistent depth by +2 levels per release cycle
 
 **Examples:**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,22 +75,23 @@ Additional notes or configuration details.
 
 **For reusable workflows and composite actions referencing actions within this repository:**
 
-- **MUST** use version tags: `Alfresco/alfresco-build-tools/.github/actions/action-name@v17.7.0`
-- **NEVER** use SHA pins: `Alfresco/alfresco-build-tools/.github/actions/action-name@abc123def456`
-- This ensures the `release.sh` script can automatically update all internal references during releases
+- **MUST** use SHA pins: `Alfresco/alfresco-build-tools/.github/actions/action-name@<40-char-sha>`
+- **NEVER** use version tags: `Alfresco/alfresco-build-tools/.github/actions/action-name@v17.7.0`
+- SHA pins are managed **automatically by the release process** — do not set them manually
+- The release workflow creates an empty commit, captures its SHA, and updates all internal refs to that SHA
 
 **Examples:**
 
-✅ **Correct (version tag):**
+✅ **Correct (SHA pin):**
+
+```yaml
+- uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+```
+
+❌ **Incorrect (version tag):**
 
 ```yaml
 - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v17.7.0
-```
-
-❌ **Incorrect (SHA pin):**
-
-```yaml
-- uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@abc123def456
 ```
 
 **For external actions (from other repositories):**
@@ -150,8 +151,8 @@ pre-commit run --all-files
 - The released version is determined from PR labels (`release/major`, `release/minor`, `release/patch`)
 - Actions will automatically be updated with the release tag by the release workflow itself, no need to do it manually
 - Release notes are auto-generated from PR titles and descriptions
-- The `release.sh` script automatically updates all internal version references that use version tags
-- **CRITICAL**: Internal references must use version tags (not SHA pins) for automatic updates to work
+- The `release.sh` script automatically pins all internal references to the SHA of the release candidate commit
+- **CRITICAL**: Internal references must use SHA pins (not version tags); these are managed automatically by the release process — do not set them manually
 
 ### Pull Request Guidelines
 
@@ -192,7 +193,7 @@ For common operations:
 ## Common Pitfalls to Avoid
 
 - **Never** skip version bumping for functional changes
-- **CRITICAL**: Never use SHA pins for internal action references (`Alfresco/alfresco-build-tools/.github/...`) - always use version tags to ensure automatic release updates work
+- **CRITICAL**: Never use version tags for internal action references (`Alfresco/alfresco-build-tools/.github/...`) - always use SHA pins (managed automatically by the release process)
 - **Don't** use `latest` tags for external actions - always pin versions
 - **Avoid** hardcoding repository-specific values in reusable actions
 - **Don't** merge PRs with user-facing changes (new features or enhancements) without updating `docs/README.md`
@@ -207,7 +208,7 @@ Before opening or reviewing a PR, verify:
 2. ✅ **Validation passed**: `./check_readme.sh` runs successfully
 3. ✅ **Version label**: Appropriate `release/patch|minor|major` label added
 4. ✅ **Pre-commit hooks**: All checks pass
-5. ✅ **Internal references**: Use version tags, not SHA pins
+5. ✅ **Internal references**: Use SHA pins (managed by release process), not version tags
 
 ## Useful Commands
 
@@ -221,14 +222,14 @@ pre-commit run --all-files
 # Test specific action locally
 cd .github/actions/action-name && bats tests/
 
-# Find all internal action references (should use version tags)
+# Find all internal action references (should use SHA pins, not version tags)
 grep -r "Alfresco/alfresco-build-tools/.github" .github/
 
-# Check for forbidden SHA pins in internal references (should return no results)
-grep -r "Alfresco/alfresco-build-tools/.github.*@[a-f0-9]\{7,\}" .github/
+# Check for forbidden version tags in internal references (should return no results)
+grep -r "Alfresco/alfresco-build-tools/.github.*@v[0-9]" .github/
 
-# Find all version tag references for release updating
-grep -r "alfresco-build-tools.*@v" .github/
+# Find all SHA-pinned internal references (the correct format)
+grep -r "alfresco-build-tools.*@[0-9a-f]\{40\}" .github/
 
 # Check for undocumented actions
 diff <(ls .github/actions) <(grep -o "### [^#]*" docs/README.md | sed 's/### //')

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -11,7 +11,32 @@ if [ -z "$RELEASE_VERSION" ] || [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-
   exit 1
 fi
 
-echo "Going to flip Alfresco-build-tools refs in actions and docs to $RELEASE_VERSION"
+if [ -z "$COMMIT_USERNAME" ] || [ -z "$COMMIT_EMAIL" ]; then
+  echo "COMMIT_USERNAME and COMMIT_EMAIL must be set for git authorship"
+  exit 1
+fi
 
-grep -Rl "Alfresco/alfresco-build-tools.*@v" | xargs sed -i -e "s/\(Alfresco\/alfresco-build-tools.*@\)v[0-9]\+\.[0-9]\+\.[0-9]\+/\1$RELEASE_VERSION/g"
-echo "Bump to $RELEASE_VERSION completed successfully."
+echo "Going to pin Alfresco-build-tools refs in .github/ to a release candidate commit (release $RELEASE_VERSION)"
+
+# Configure git authorship for the empty commit
+git config user.name "$COMMIT_USERNAME"
+git config user.email "$COMMIT_EMAIL"
+
+# Create an empty commit to obtain a stable SHA to pin internal action refs to.
+# This avoids the chicken-and-egg: the tagged release commit (SHA2) will reference SHA1 (the empty
+# commit), which carries the same code tree. The SHA of SHA2 cannot be known before it is created.
+git commit --allow-empty -m "Release candidate $RELEASE_VERSION"
+RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
+
+# SHA-pin internal refs in action/workflow files (.github/ only — these are executed and subject to org policy)
+# Replaces both existing SHA pins (@<40hexchars>) and version tags (@v1.2.3) with the release candidate SHA
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
+  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$RELEASE_COMMIT_SHA|g"
+echo "SHA-pin to $RELEASE_COMMIT_SHA in .github/ completed successfully."
+
+# Update version tags in docs/ (user-facing documentation stays human-readable with semver tags)
+if grep -Rql "Alfresco/alfresco-build-tools.*@v" docs/; then
+  grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -e \
+    "s/\(Alfresco\/alfresco-build-tools[^@]*@\)v[0-9]\+\.[0-9]\+\.[0-9]\+/\1$RELEASE_VERSION/g"
+  echo "Version bump to $RELEASE_VERSION in docs/ completed successfully."
+fi

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -11,23 +11,36 @@ if [ -z "$RELEASE_VERSION" ] || [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-
   exit 1
 fi
 
-echo "Going to pin Alfresco-build-tools refs in .github/ to a release candidate commit (release $RELEASE_VERSION)"
-
-# Capture the current HEAD SHA to use as the pin target.
-# This avoids the chicken-and-egg: the tagged release commit (SHA2) will reference SHA_PREV
-# (the last merged commit), which carries the same code tree as SHA2.
-# The SHA of SHA2 itself cannot be known before it is created.
-RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
-
-# SHA-pin internal refs in action/workflow files (.github/ only — these are executed and subject to org policy)
-# Replaces both existing SHA pins (@<40hexchars>) and version tags (@v1.2.3) with the release candidate SHA
-grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
-  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$RELEASE_COMMIT_SHA|g"
-echo "SHA-pin to $RELEASE_COMMIT_SHA in .github/ completed successfully."
-
-# Update version tags in docs/ (user-facing documentation stays human-readable with semver tags)
-if grep -Rql "Alfresco/alfresco-build-tools.*@v" docs/; then
-  grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -e \
-    "s/\(Alfresco\/alfresco-build-tools[^@]*@\)v[0-9]\+\.[0-9]\+\.[0-9]\+/\1$RELEASE_VERSION/g"
-  echo "Version bump to $RELEASE_VERSION in docs/ completed successfully."
+if [ -z "$COMMIT_USERNAME" ] || [ -z "$COMMIT_EMAIL" ]; then
+  echo "COMMIT_USERNAME and COMMIT_EMAIL must be set for git authorship"
+  exit 1
 fi
+
+echo "Going to pin Alfresco-build-tools refs via two-pass approach (release $RELEASE_VERSION)"
+
+git config user.name "$COMMIT_USERNAME"
+git config user.email "$COMMIT_EMAIL"
+
+# Pass 1: release candidate commit
+# Pin all .github/ refs to SHA_PREV (the last merged commit).
+SHA_PREV=$(git rev-parse HEAD)
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
+  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_PREV|g"
+
+# Update version tags in docs/ (human-readable semver for user-facing documentation)
+grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -e \
+  "s/\(Alfresco\/alfresco-build-tools[^@]*@\)v[0-9]\+\.[0-9]\+\.[0-9]\+/\1$RELEASE_VERSION/g"
+
+git add -A
+git commit -m "Release candidate $RELEASE_VERSION"
+SHA_RC=$(git rev-parse HEAD)
+echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, created SHA_RC=$SHA_RC"
+
+# Pass 2: release commit (picked up by git-auto-commit-action)
+# Pin all .github/ refs to SHA_RC so the tagged release commit references the
+# candidate commit, which in turn references SHA_PREV (the actual code). This is
+# necessary to ensure all the nested actions refs are resolved to the latest
+# code and not the previous release.
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
+  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_RC|g"
+echo "Pass 2 complete: pinned refs to SHA_RC=$SHA_RC (git-auto-commit-action will create the final release commit)"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -38,9 +38,9 @@ echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, created SHA_RC=$SHA_RC
 
 # Pass 2: release commit (picked up by git-auto-commit-action)
 # Pin all .github/ refs to SHA_RC so the tagged release commit references the
-# candidate commit, which in turn references SHA_PREV (the actual code). This is
-# necessary to ensure all the nested actions refs are resolved to the latest
-# code and not the previous release.
+# candidate commit, which in turn references SHA_PREV (the actual code).
+# Each release adds 2 more levels of consistent nesting depth; deeper chains
+# gain full consistency over successive releases.
 grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -e \
   "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_RC|g"
 echo "Pass 2 complete: pinned refs to SHA_RC=$SHA_RC (git-auto-commit-action will create the final release commit)"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -11,21 +11,12 @@ if [ -z "$RELEASE_VERSION" ] || [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-
   exit 1
 fi
 
-if [ -z "$COMMIT_USERNAME" ] || [ -z "$COMMIT_EMAIL" ]; then
-  echo "COMMIT_USERNAME and COMMIT_EMAIL must be set for git authorship"
-  exit 1
-fi
-
 echo "Going to pin Alfresco-build-tools refs in .github/ to a release candidate commit (release $RELEASE_VERSION)"
 
-# Configure git authorship for the empty commit
-git config user.name "$COMMIT_USERNAME"
-git config user.email "$COMMIT_EMAIL"
-
-# Create an empty commit to obtain a stable SHA to pin internal action refs to.
-# This avoids the chicken-and-egg: the tagged release commit (SHA2) will reference SHA1 (the empty
-# commit), which carries the same code tree. The SHA of SHA2 cannot be known before it is created.
-git commit --allow-empty -m "Release candidate $RELEASE_VERSION"
+# Capture the current HEAD SHA to use as the pin target.
+# This avoids the chicken-and-egg: the tagged release commit (SHA2) will reference SHA_PREV
+# (the last merged commit), which carries the same code tree as SHA2.
+# The SHA of SHA2 itself cannot be known before it is created.
 RELEASE_COMMIT_SHA=$(git rev-parse HEAD)
 
 # SHA-pin internal refs in action/workflow files (.github/ only — these are executed and subject to org policy)

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -24,7 +24,7 @@ git config user.email "$COMMIT_EMAIL"
 # Pass 1: release candidate commit
 # Pin all .github/ refs to SHA_PREV (the last merged commit).
 SHA_PREV=$(git rev-parse HEAD)
-grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -e \
   "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_PREV|g"
 
 # Update version tags in docs/ (human-readable semver for user-facing documentation)
@@ -41,6 +41,6 @@ echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, created SHA_RC=$SHA_RC
 # candidate commit, which in turn references SHA_PREV (the actual code). This is
 # necessary to ensure all the nested actions refs are resolved to the latest
 # code and not the previous release.
-grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ | xargs sed -i -e \
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -e \
   "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_RC|g"
 echo "Pass 2 complete: pinned refs to SHA_RC=$SHA_RC (git-auto-commit-action will create the final release commit)"

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -118,6 +118,8 @@ jobs:
             env:
               RELEASE_VERSION: ${{ steps.bump-semver.outputs.new-version }}
               CURRENT_VERSION: ${{ steps.bump-semver.outputs.current-version }}
+              COMMIT_USERNAME: ${{ inputs.commit_username }}
+              COMMIT_EMAIL: ${{ inputs.commit_email }}
             run: |
               ${{ inputs.release_command }}
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -118,8 +118,6 @@ jobs:
             env:
               RELEASE_VERSION: ${{ steps.bump-semver.outputs.new-version }}
               CURRENT_VERSION: ${{ steps.bump-semver.outputs.current-version }}
-              COMMIT_USERNAME: ${{ inputs.commit_username }}
-              COMMIT_EMAIL: ${{ inputs.commit_email }}
             run: |
               ${{ inputs.release_command }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'test/local-actions')
         run: |
           find .github/actions -name "action.yml" -type f \
-            -exec sed -i 's|uses: Alfresco/alfresco-build-tools/\.github/actions/\([^@]*\)@v[0-9]\+\.[0-9]\+\.[0-9]\+|uses: ./.github/actions/\1|g' {} \;
+            -exec sed -i 's|uses: Alfresco/alfresco-build-tools/\.github/actions/\([^@]*\)@\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|uses: ./.github/actions/\1|g' {} \;
           git diff
 
       - name: Test HTTP latency

--- a/docs/README.md
+++ b/docs/README.md
@@ -2649,8 +2649,10 @@ jobs:
 
 Release command has access to the following environment variables:
 
-- RELEASE_VERSION: the new version calculated
-- CURRENT_VERSION: the previous version
+- `RELEASE_VERSION`: the new version calculated
+- `CURRENT_VERSION`: the previous version
+- `COMMIT_USERNAME`: the configured commit username (from `commit_username` input)
+- `COMMIT_EMAIL`: the configured commit email (from `commit_email` input)
 
 ### terraform
 


### PR DESCRIPTION
OPSEXP-4052

## Problem

GitHub org policy now blocks version-tag references (`@v17.7.0`) inside action/workflow files. All internal `Alfresco/alfresco-build-tools` references must use SHA pins.

This creates a chicken-and-egg problem: a commit cannot contain its own SHA, since the SHA is computed from the file contents.

## Solution: Two-Pass Release

The `release.sh` script uses a two-pass approach to achieve growing SHA-pin consistency depth across release cycles.

### Release commit sequence

Given current HEAD as `SHA_PREV` (last merged PR):

**Pass 1** — create a release candidate commit:
- Pin all `.github/` refs → `@SHA_PREV`
- Bump `docs/` version tags → `@vNEW` (human-readable, for users)
- `git commit` → produces `SHA_RC`

**Pass 2** — prepare the final release commit (working tree only):
- Pin all `.github/` refs → `@SHA_RC`
- `git-auto-commit-action` picks this up and commits → `SHA_B` (tagged `vNEW`)

### Resulting git history

```
... → [SHA_PREV: merged PR] → [SHA_RC: Release candidate vNEW] → [SHA_B: Release vNEW] ← tag vNEW
```

### Consistency depth grows per release

Each release adds +2 consistent levels of action nesting:

| Release cycle | Consistent levels |
|---|---|
| First release with this approach | 3 |
| Second release | 5 |
| Third release | 7 |

After a few releases, any realistic composite-action nesting depth is fully covered.

## Changes

- **`.github/scripts/release.sh`**: two-pass SHA-pin logic; replaces both `@v1.2.3` version tags and `@<40hexsha>` existing pins; `docs/` gets a semver bump for readability
- **`.github/workflows/reusable-release.yml`**: passes `COMMIT_USERNAME` and `COMMIT_EMAIL` to the release command env so `release.sh` can configure git authorship for the candidate commit
- **`.github/workflows/test.yml`**: extends the `test/local-actions` sed rewrite to also match `@<40hexsha>` refs (not just `@v1.2.3`)
- **`.github/copilot-instructions.md`**: flips the convention — SHA pins are correct for internal refs, version tags are incorrect

## Version bump

- [ ] patch
- [ ] minor
- [x] major