### PR TITLE
chore: pin all internal action refs from v17.7.0 to SHA

### DIFF
--- a/.github/actions/calculate-next-internal-version/action.yml
+++ b/.github/actions/calculate-next-internal-version/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@9f51752cb7845dce8e8b13b866c127681f418bb3
     - id: next-prerelease-resolver
       run: ${{ github.action_path }}/next-prerelease.sh
       shell: bash

--- a/.github/actions/dbp-charts/verify-helm/action.yml
+++ b/.github/actions/dbp-charts/verify-helm/action.yml
@@ -86,14 +86,14 @@ runs:
     - name: Get branch name
       id: get-branch-name
       uses: >-
-        Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+        Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
     - name: Get commit msg
       uses: >-
-        Alfresco/alfresco-build-tools/.github/actions/get-commit-message@v17.7.0
+        Alfresco/alfresco-build-tools/.github/actions/get-commit-message@9f51752cb7845dce8e8b13b866c127681f418bb3
     - name: Get a namespace to deploy on
       id: k8sns
       uses: >-
-        Alfresco/alfresco-build-tools/.github/actions/dbp-charts/kubernetes-valid-ns@v17.7.0
+        Alfresco/alfresco-build-tools/.github/actions/dbp-charts/kubernetes-valid-ns@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         branch_name: ${{ steps.get-branch-name.outputs.branch-name }}
         release_prefix: ${{ inputs.release_prefix }}
@@ -112,7 +112,7 @@ runs:
     - name: Upload helm deployments logs as artifacts
       if: always()
       uses: >-
-        Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@v17.7.0
+        Alfresco/alfresco-build-tools/.github/actions/kubectl-keep-nslogs@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         namespace: ${{ steps.k8sns.outputs.namespace }}
     - name: Uninstall Helm releases

--- a/.github/actions/enforce-pr-conventions/action.yml
+++ b/.github/actions/enforce-pr-conventions/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Get branch name
       id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
 
     - name: Check is Dependabot PR or Propagation PR
       id: check

--- a/.github/actions/get-branch-name/action.yml
+++ b/.github/actions/get-branch-name/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         sanitize: ${{ inputs.sanitize }}
         max-length: ${{ inputs.max-length }}

--- a/.github/actions/get-build-info/action.yml
+++ b/.github/actions/get-build-info/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: "Get branch name"
       id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
     - name: "Get build info"
       run: |
         [[ $GITHUB_EVENT_NAME == "pull_request" ]] && IS_PULL_REQUEST="true" || IS_PULL_REQUEST="false"

--- a/.github/actions/github-check-upcoming-runs/action.yml
+++ b/.github/actions/github-check-upcoming-runs/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Get branch name
       id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
 
     - name: Check upcoming runs
       id: check

--- a/.github/actions/github-deployment-create/action.yml
+++ b/.github/actions/github-deployment-create/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Update Deployment State
       if: ${{ inputs.state != '' }}
-      uses: Alfresco/alfresco-build-tools/.github/actions/github-deployment-status-update@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/github-deployment-status-update@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         github-token: ${{ inputs.github-token }}
         deployment-id: ${{ steps.create.outputs.id }}

--- a/.github/actions/helm-integration-tests/action.yml
+++ b/.github/actions/helm-integration-tests/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: Setup rancher
-      uses: Alfresco/alfresco-build-tools/.github/actions/setup-rancher-cli@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/setup-rancher-cli@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         url: ${{ inputs.test-rancher-url }}
         access-key: ${{ inputs.test-rancher-access-key }}

--- a/.github/actions/helm-publish-chart/action.yml
+++ b/.github/actions/helm-publish-chart/action.yml
@@ -110,7 +110,7 @@ runs:
         fi
 
     - name: Commit changes
-      uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         username: ${{ inputs.git-username }}
         add-options: .

--- a/.github/actions/helm-release-and-publish/action.yml
+++ b/.github/actions/helm-release-and-publish/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: check-tag
       with:
         tag: ${{ env.VERSION }}
@@ -55,14 +55,14 @@ runs:
 
     - name: Update chart version
       if: steps.check-tag.outputs.exists == 'false'
-      uses: Alfresco/alfresco-build-tools/.github/actions/helm-update-chart-version@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/helm-update-chart-version@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         new-version: ${{ env.VERSION }}
         chart-repository-dir: ${{ inputs.chart-repository-dir }}
         chart-dir: ${{ inputs.chart-dir }}
         helm-docs-version: ${{ inputs.helm-docs-version }}
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
       if: steps.check-tag.outputs.exists == 'false'
       with:
         username: ${{ inputs.git-username }}
@@ -79,7 +79,7 @@ runs:
     - name: Package Helm Chart
       if: steps.check-tag.outputs.exists == 'false'
       id: package-helm-chart
-      uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         chart-dir: ${{ inputs.chart-dir }}
         chart-repository-dir: ${{ inputs.chart-repository-dir }}
@@ -92,7 +92,7 @@ runs:
 
     - name: Publish Helm chart
       if: steps.check-tag.outputs.exists == 'false'
-      uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         helm-charts-repo: ${{inputs.helm-repository}}
         helm-charts-repo-branch: ${{ inputs.helm-repository-branch }}

--- a/.github/actions/helm-update-chart-version/action.yml
+++ b/.github/actions/helm-update-chart-version/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-helm-docs@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         version: ${{ inputs.helm-docs-version }}
     - name: Update version

--- a/.github/actions/jira-propagate-release/action.yml
+++ b/.github/actions/jira-propagate-release/action.yml
@@ -64,7 +64,7 @@ runs:
 
     - name: Get or create Jira release/version
       id: jira-release
-      uses: Alfresco/alfresco-build-tools/.github/actions/jira-get-or-create-release@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/jira-get-or-create-release@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         jira-url: ${{ inputs.jira-url }}
         jira-project-key: ${{ inputs.jira-project-key }}
@@ -76,7 +76,7 @@ runs:
     - name: Set Fix Version on tickets (skip if none)
       id: set-fix
       if: ${{ steps.extract.outputs.tickets-csv != '' }}
-      uses: Alfresco/alfresco-build-tools/.github/actions/jira-set-fix-version@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/jira-set-fix-version@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         jira-url: ${{ inputs.jira-url }}
         jira-user: ${{ inputs.jira-user }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -109,7 +109,7 @@ runs:
   steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: maven-configure
       with:
         java-version: ${{ inputs.java-version }}
@@ -122,7 +122,7 @@ runs:
     - name: Update pom files to the new version
       id: update-pom-to-next-version
       if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.maven-configure.outputs.maven-options }}
@@ -225,7 +225,7 @@ runs:
       shell: bash
       run: find . -name TEST-*.xml -exec grep -h testcase {} \; | awk -F '"' '{printf("%s#%s() - %.3fms\n", $4, $2, $6); }' | sort -n -k 3 | tail -20
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
       if: github.event_name == 'push'
       with:
         username: ${{ inputs.git-username }}

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -92,7 +92,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: maven-configure
       with:
         java-version: ${{ inputs.java-version }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Update pom files to the preview version
       if: steps.maven-configure.outputs.preview-version != ''
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@9f51752cb7845dce8e8b13b866c127681f418bb3
 
       with:
         version: ${{ steps.maven-configure.outputs.preview-version }}

--- a/.github/actions/maven-dependency-scan/action.yml
+++ b/.github/actions/maven-dependency-scan/action.yml
@@ -45,7 +45,7 @@ runs:
         merge-multiple: true
         path: ${{ inputs.restore-artifact-path }}
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: maven-configure
       with:
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/maven-release/action.yml
+++ b/.github/actions/maven-release/action.yml
@@ -75,7 +75,7 @@ runs:
         path: '${{ env.REPO_DIR }}'
         token: ${{ inputs.github-token }}
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-check-existing-tag@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: check-tag
       with:
         tag: ${{ env.RELEASE_VERSION }}
@@ -147,7 +147,7 @@ runs:
 
     - name: Commit changes
       if: steps.check-tag.outputs.exists == 'false'
-      uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         username: ${{ inputs.git-username }}
         add-options: -u

--- a/.github/actions/maven-tag/action.yml
+++ b/.github/actions/maven-tag/action.yml
@@ -38,7 +38,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/maven-configure@9f51752cb7845dce8e8b13b866c127681f418bb3
       id: maven-configure
       with:
         java-version: ${{ inputs.java-version }}
@@ -46,7 +46,7 @@ runs:
 
     - name: Update pom files to the new version
       id: update-pom-to-next-version
-      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         property-to-update: ${{ inputs.property-to-update }}
         maven-cli-opts: ${{ steps.maven-configure.outputs.maven-options }}
@@ -81,7 +81,7 @@ runs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
-    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         username: ${{ inputs.git-username }}
         add-options: -u

--- a/.github/actions/reportportal-prepare/action.yml
+++ b/.github/actions/reportportal-prepare/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Get branch name
       id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
 
     - name: Compute Report Portal input info
       id: info

--- a/.github/actions/send-teams-notification/action.yml
+++ b/.github/actions/send-teams-notification/action.yml
@@ -161,7 +161,7 @@ runs:
 
     - name: Get branch name
       id: get-branch-name
-      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
 
     - name: Transform mentions to JSON entities
       id: transform-mentions

--- a/.github/actions/setup-checkov/action.yml
+++ b/.github/actions/setup-checkov/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: bridgecrewio/checkov
         version: ${{ inputs.version }}

--- a/.github/actions/setup-fluxcli/action.yml
+++ b/.github/actions/setup-fluxcli/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         binary_name: flux
         repo: fluxcd/flux2

--- a/.github/actions/setup-helm-docs/action.yml
+++ b/.github/actions/setup-helm-docs/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: norwoodj/helm-docs
         version: ${{ inputs.version != '' && inputs.version || env.DEFAULT_HELM_DOCS_VERSION }}

--- a/.github/actions/setup-jx-release-version/action.yml
+++ b/.github/actions/setup-jx-release-version/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: jenkins-x-plugins/jx-release-version
         version: ${{ inputs.version }}

--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -145,7 +145,7 @@ runs:
 
     - name: Setup cloud-provider-kind
       if: inputs.cloud-provider-kind-enabled == 'true'
-      uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         binary_name: cloud-provider-kind
         repo: kubernetes-sigs/cloud-provider-kind

--- a/.github/actions/setup-kubepug/action.yml
+++ b/.github/actions/setup-kubepug/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: kubepug/kubepug
         version: ${{ inputs.version }}

--- a/.github/actions/setup-terraform-docs/action.yml
+++ b/.github/actions/setup-terraform-docs/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: terraform-docs/terraform-docs
         version: ${{ inputs.version }}

--- a/.github/actions/setup-updatecli/action.yml
+++ b/.github/actions/setup-updatecli/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@v17.7.0
+    - uses: Alfresco/alfresco-build-tools/.github/actions/setup-github-release-binary@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         repo: updatecli/updatecli
         version: ${{ inputs.version }}

--- a/.github/actions/sonar-scan-on-built-project/action.yml
+++ b/.github/actions/sonar-scan-on-built-project/action.yml
@@ -73,7 +73,7 @@ runs:
         path: ${{ inputs.m2-uploaded-group-path }}
 
     - name: SonarQube Scan
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-build@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-build@9f51752cb7845dce8e8b13b866c127681f418bb3
       env:
         SONAR_TOKEN: ${{ inputs.sonar-token }}
       with:

--- a/.github/actions/update-pom-to-next-pre-release/action.yml
+++ b/.github/actions/update-pom-to-next-pre-release/action.yml
@@ -33,7 +33,7 @@ runs:
     - id: next-prerelease-resolver
       name: Calculate next internal release
       if: inputs.version == ''
-      uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         next-version: ${{ steps.parse-next-final-version.outputs.result }}
         prerelease-type: ${{ inputs.prerelease-type }}
@@ -50,7 +50,7 @@ runs:
         fi
 
     - name: Update pom files to the new version
-      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@v17.7.0
+      uses: Alfresco/alfresco-build-tools/.github/actions/maven-update-pom-version@9f51752cb7845dce8e8b13b866c127681f418bb3
       with:
         version: ${{ steps.resolve-version.outputs.version }}
         maven-cli-opts: ${{ inputs.maven-cli-opts }}

--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v17.7.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -109,11 +109,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v17.7.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v17.7.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}

--- a/.github/workflows/helm-publish-new-package-version.yml
+++ b/.github/workflows/helm-publish-new-package-version.yml
@@ -46,7 +46,7 @@ jobs:
 
       - id: next-release
         name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           next-version: ${{ inputs.next-version }}
 
@@ -57,13 +57,13 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Update chart version
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-update-chart-version@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-update-chart-version@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           new-version: ${{ env.VERSION }}
           chart-dir: ${{ inputs.chart-dir }}
           helm-docs-version: ${{ inputs.helm-docs-version }}
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v17.7.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           add-options: -u
@@ -74,7 +74,7 @@ jobs:
 
       - name: Package Helm Chart
         id: package-helm-chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           chart-dir: ${{ inputs.chart-dir }}
 
@@ -82,7 +82,7 @@ jobs:
         run: git push origin "$VERSION"
 
       - name: Publish Helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
             helm-charts-repo: ${{ inputs.helm-charts-repo }}
             helm-charts-repo-branch: ${{ inputs.helm-charts-repo-branch }}

--- a/.github/workflows/pr-review-check.yml
+++ b/.github/workflows/pr-review-check.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Trigger validation on approval
         if: github.event_name == 'pull_request_review'
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-trigger-approved-pr@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-trigger-approved-pr@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           creator: ${{ env.DEPENDABOT_CREATOR }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Trigger validation on labeling when token is not readonly and milestone is set
         if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.secret_source == 'Actions' && inputs.milestone-name != ''
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-trigger-labeled-pr@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-trigger-labeled-pr@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           labels: ${{ inputs.trigger-labels }}

--- a/.github/workflows/terraform-pre-commit.yml
+++ b/.github/workflows/terraform-pre-commit.yml
@@ -28,14 +28,14 @@ jobs:
         uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6.2.2
 
       - name: Install checkov
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-checkov@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-checkov@9f51752cb7845dce8e8b13b866c127681f418bb3
 
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ steps.detect-terraform-version.outputs.terraform_version }}
 
       - name: Install terraform-docs
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-terraform-docs@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-terraform-docs@9f51752cb7845dce8e8b13b866c127681f418bb3
 
       - name: Setup authentication for private terraform modules
         if: env.BOT_GITHUB_USERNAME && env.BOT_GITHUB_TOKEN
@@ -45,7 +45,7 @@ jobs:
         run: |
           git config --global url."https://${BOT_GITHUB_USERNAME}:${BOT_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v17.7.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           auto-commit: "true" # optionally commit automated fix changes back
           skip_checkout: "false" # mandatory with auto-commit

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Evaluate current branch
         id: get-branch-name
-        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name-v2@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           additional-pr-events: true
 
@@ -147,7 +147,7 @@ jobs:
       - name: Retrieve PR or last commit changes (used for auto-detection of terraform root path and/or environment)
         if: inputs.terraform_root_path == '' || inputs.terraform_env == ''
         id: last-changes-diff
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -480,7 +480,7 @@ jobs:
           role-session-name: TerraformWorkflow
 
       - name: Load environment variables from yml
-        uses: Alfresco/alfresco-build-tools/.github/actions/env-load-from-yaml@v17.7.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/env-load-from-yaml@9f51752cb7845dce8e8b13b866c127681f418bb3
         with:
           yml_path: ${{ needs.compute_basic_vars.outputs.terraform_root_path }}/tfenv.yml
 


### PR DESCRIPTION
OPSEXP-4052

Replace all Alfresco/alfresco-build-tools internal references using the semver tag @v17.7.0 with the equivalent commit SHA pin @9f51752cb7845dce8e8b13b866c127681f418bb3.

This is a prerequisite for the two-pass SHA-pin release process (https://github.com/Alfresco/alfresco-build-tools/pull/1398): the release script replaces both semver tags and existing SHA pins, so having everything on a SHA pin before the first release ensures the transition is clean.