### PR TITLE
fix: release script fails to replace internal action SHA refs

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -24,12 +24,12 @@ git config user.email "$COMMIT_EMAIL"
 # Pass 1: release candidate commit
 # Pin all .github/ refs to SHA_PREV (the last merged commit).
 SHA_PREV=$(git rev-parse HEAD)
-grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -e \
-  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_PREV|g"
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -E \
+  "s|(Alfresco/alfresco-build-tools[^@]*@)[0-9a-f]{40}|\1$SHA_PREV|g"
 
 # Update version tags in docs/ (human-readable semver for user-facing documentation)
-grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -e \
-  "s/\(Alfresco\/alfresco-build-tools[^@]*@\)v[0-9]\+\.[0-9]\+\.[0-9]\+/\1$RELEASE_VERSION/g"
+grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
+  "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
 git add -A
 git commit -m "Release candidate $RELEASE_VERSION"
@@ -41,6 +41,6 @@ echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, created SHA_RC=$SHA_RC
 # candidate commit, which in turn references SHA_PREV (the actual code).
 # Each release adds 2 more levels of consistent nesting depth; deeper chains
 # gain full consistency over successive releases.
-grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -e \
-  "s|\(Alfresco/alfresco-build-tools[^@]*@\)\([0-9a-f]\{40\}\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)|\1$SHA_RC|g"
+grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs sed -i -E \
+  "s|(Alfresco/alfresco-build-tools[^@]*@)[0-9a-f]{40}|\1$SHA_RC|g"
 echo "Pass 2 complete: pinned refs to SHA_RC=$SHA_RC (git-auto-commit-action will create the final release commit)"


### PR DESCRIPTION
## Problem

The `release.sh` script was silently not replacing any internal action SHA references during the release process. The root cause was the use of BRE (Basic Regular Expressions) with GNU-only escape sequences (`\|`, `\+`, `\{\}\ `) that are not portable and caused the sed substitution to fail without error.

Additionally, the pattern included a semver tag alternation (`v[0-9]+...`) which is no longer needed once all internal refs are SHA-pinned (handled by the prerequisite PR https://github.com/Alfresco/alfresco-build-tools/pull/1399).

## Solution

- Switch all `sed` calls from `-e` (BRE) to `-E` (ERE) for portable, clean regex syntax
- Simplify the SHA pattern to an exact 40-character hex match: `[0-9a-f]{40}`

## Related

Companion fix for the two-pass SHA-pin release approach introduced in #1398.

- [ ] release/patch