### PR TITLE
fix: ignore Alfresco/alfresco-build-tools in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # Documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# Edit should be made in the dependabot.template.yml
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -25,6 +24,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      # SHA pins for internal actions are managed by the release script; dependabot must not touch them
+      - dependency-name: "Alfresco/alfresco-build-tools"
 
   - package-ecosystem: "pip"
     directories:


### PR DESCRIPTION
OPSEXP-4052

## Problem

The release script pins all internal `Alfresco/alfresco-build-tools` action SHA refs on every merge to master. Dependabot sees these rotating SHAs as "outdated" and opens spurious update PRs (e.g. `dependabot/github_actions/github-actions-c475705bc3`).

## Fix

- Add an `ignore` rule for `Alfresco/alfresco-build-tools` under the `github-actions` dependabot ecosystem — these SHA pins are managed exclusively by the release script.
- Remove stale comment referencing `dependabot.template.yml` (file no longer exists).
