### PR TITLE
AAE-45986 Disambiguate concurrent dispatches by matching inputs

### DIFF
--- a/.github/actions/dispatch-resume-workflow/dist/index.js
+++ b/.github/actions/dispatch-resume-workflow/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n
-        Error Code : ${error.statusCode}\n
+                throw new Error(`Failed to get ID Token. \n 
+        Error Code : ${error.statusCode}\n 
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -2205,11 +2205,11 @@ var __copyProps = (to, from, except, desc) => {
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // pkg/dist-src/index.js
-var dist_src_exports = {};
-__export(dist_src_exports, {
+var index_exports = {};
+__export(index_exports, {
   Octokit: () => Octokit
 });
-module.exports = __toCommonJS(dist_src_exports);
+module.exports = __toCommonJS(index_exports);
 var import_universal_user_agent = __nccwpck_require__(5030);
 var import_before_after_hook = __nccwpck_require__(3682);
 var import_request = __nccwpck_require__(6234);
@@ -2217,13 +2217,28 @@ var import_graphql = __nccwpck_require__(8467);
 var import_auth_token = __nccwpck_require__(334);
 
 // pkg/dist-src/version.js
-var VERSION = "5.2.0";
+var VERSION = "5.2.2";
 
 // pkg/dist-src/index.js
 var noop = () => {
 };
 var consoleWarn = console.warn.bind(console);
 var consoleError = console.error.bind(console);
+function createLogger(logger = {}) {
+  if (typeof logger.debug !== "function") {
+    logger.debug = noop;
+  }
+  if (typeof logger.info !== "function") {
+    logger.info = noop;
+  }
+  if (typeof logger.warn !== "function") {
+    logger.warn = consoleWarn;
+  }
+  if (typeof logger.error !== "function") {
+    logger.error = consoleError;
+  }
+  return logger;
+}
 var userAgentTrail = `octokit-core.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
 var Octokit = class {
   static {
@@ -2297,15 +2312,7 @@ var Octokit = class {
     }
     this.request = import_request.request.defaults(requestDefaults);
     this.graphql = (0, import_graphql.withCustomRequest)(this.request).defaults(requestDefaults);
-    this.log = Object.assign(
-      {
-        debug: noop,
-        info: noop,
-        warn: consoleWarn,
-        error: consoleError
-      },
-      options.log
-    );
+    this.log = createLogger(options.log);
     this.hook = hook;
     if (!options.authStrategy) {
       if (!options.auth) {
@@ -2384,7 +2391,7 @@ module.exports = __toCommonJS(dist_src_exports);
 var import_universal_user_agent = __nccwpck_require__(5030);
 
 // pkg/dist-src/version.js
-var VERSION = "9.0.5";
+var VERSION = "9.0.6";
 
 // pkg/dist-src/defaults.js
 var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
@@ -2489,9 +2496,9 @@ function addQueryParameters(url, parameters) {
 }
 
 // pkg/dist-src/util/extract-url-variable-names.js
-var urlVariableRegex = /\{[^}]+\}/g;
+var urlVariableRegex = /\{[^{}}]+\}/g;
 function removeNonChars(variableName) {
-  return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+  return variableName.replace(/(?:^\W+)|(?:(?<!\W)\W+$)/g, "").split(/,/);
 }
 function extractUrlVariableNames(url) {
   const matches = url.match(urlVariableRegex);
@@ -2677,7 +2684,7 @@ function parse(options) {
     }
     if (url.endsWith("/graphql")) {
       if (options.mediaType.previews?.length) {
-        const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+        const previewsFromAcceptHeader = headers.accept.match(/(?<![\w-])[\w-]+(?=-preview)/g) || [];
         headers.accept = previewsFromAcceptHeader.concat(options.mediaType.previews).map((preview) => {
           const format = options.mediaType.format ? `.${options.mediaType.format}` : "+json";
           return `application/vnd.github.${preview}-preview${format}`;
@@ -2758,18 +2765,18 @@ var __copyProps = (to, from, except, desc) => {
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // pkg/dist-src/index.js
-var dist_src_exports = {};
-__export(dist_src_exports, {
+var index_exports = {};
+__export(index_exports, {
   GraphqlResponseError: () => GraphqlResponseError,
   graphql: () => graphql2,
   withCustomRequest: () => withCustomRequest
 });
-module.exports = __toCommonJS(dist_src_exports);
+module.exports = __toCommonJS(index_exports);
 var import_request3 = __nccwpck_require__(6234);
 var import_universal_user_agent = __nccwpck_require__(5030);
 
 // pkg/dist-src/version.js
-var VERSION = "7.1.0";
+var VERSION = "7.1.1";
 
 // pkg/dist-src/with-defaults.js
 var import_request2 = __nccwpck_require__(6234);
@@ -2817,8 +2824,7 @@ function graphql(request2, query, options) {
       );
     }
     for (const key in options) {
-      if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key))
-        continue;
+      if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key)) continue;
       return Promise.reject(
         new Error(
           `[@octokit/graphql] "${key}" cannot be used as variable name`
@@ -2926,7 +2932,7 @@ __export(dist_src_exports, {
 module.exports = __toCommonJS(dist_src_exports);
 
 // pkg/dist-src/version.js
-var VERSION = "9.2.1";
+var VERSION = "9.2.2";
 
 // pkg/dist-src/normalize-paginated-list-response.js
 function normalizePaginatedListResponse(response) {
@@ -2974,7 +2980,7 @@ function iterator(octokit, route, parameters) {
           const response = await requestMethod({ method, url, headers });
           const normalizedResponse = normalizePaginatedListResponse(response);
           url = ((normalizedResponse.headers.link || "").match(
-            /<([^>]+)>;\s*rel="next"/
+            /<([^<>]+)>;\s*rel="next"/
           ) || [])[1];
           return { value: normalizedResponse };
         } catch (error) {
@@ -5526,7 +5532,7 @@ var RequestError = class extends Error {
     if (options.request.headers.authorization) {
       requestCopy.headers = Object.assign({}, options.request.headers, {
         authorization: options.request.headers.authorization.replace(
-          / .*$/,
+          /(?<! ) .*$/,
           " [REDACTED]"
         )
       });
@@ -5594,7 +5600,7 @@ var import_endpoint = __nccwpck_require__(9440);
 var import_universal_user_agent = __nccwpck_require__(5030);
 
 // pkg/dist-src/version.js
-var VERSION = "8.4.0";
+var VERSION = "8.4.1";
 
 // pkg/dist-src/is-plain-object.js
 function isPlainObject(value) {
@@ -5653,7 +5659,7 @@ function fetchWrapper(requestOptions) {
       headers[keyAndValue[0]] = keyAndValue[1];
     }
     if ("deprecation" in headers) {
-      const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+      const matches = headers.link && headers.link.match(/<([^<>]+)>; rel="deprecation"/);
       const deprecationLink = matches && matches.pop();
       log.warn(
         `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
@@ -11657,7 +11663,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(4408)
-const { stringify, getHeadersList } = __nccwpck_require__(3121)
+const { stringify } = __nccwpck_require__(3121)
 const { webidl } = __nccwpck_require__(1744)
 const { Headers } = __nccwpck_require__(554)
 
@@ -11733,14 +11739,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**
@@ -12168,14 +12173,15 @@ module.exports = {
 /***/ }),
 
 /***/ 3121:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ ((module) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(9491)
-const { kHeadersList } = __nccwpck_require__(2785)
-
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -12436,31 +12442,13 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  if (headers[kHeadersList]) {
-    return headers[kHeadersList]
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
-  stringify,
-  getHeadersList
+  validateCookieName,
+  validateCookiePath,
+  validateCookieValue,
+  toIMFDate,
+  stringify
 }
 
 
@@ -16464,6 +16452,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(2538)
+const util = __nccwpck_require__(3837)
 const { webidl } = __nccwpck_require__(1744)
 const assert = __nccwpck_require__(9491)
 
@@ -17017,6 +17006,9 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
+  },
+  [util.inspect.custom]: {
+    enumerable: false
   }
 })
 
@@ -26193,6 +26185,20 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
+
+    this.on('connectionError', (origin, targets, error) => {
+      // If a connection error occurs, we remove the client from the pool,
+      // and emit a connectionError event. They will not be re-used.
+      // Fixes https://github.com/nodejs/undici/issues/3895
+      for (const target of targets) {
+        // Do not use kRemoveClient here, as it will close the client,
+        // but the client cannot be closed in this state.
+        const idx = this[kClients].indexOf(target)
+        if (idx !== -1) {
+          this[kClients].splice(idx, 1)
+        }
+      }
+    })
   }
 
   [kGetDispatcher] () {
@@ -29651,6 +29657,7 @@ class WorkflowHandler {
             try {
                 const workflowId = yield this.getWorkflowId();
                 this.triggerDate = new Date().setMilliseconds(0);
+                this.dispatchedInputs = inputs;
                 const dispatchResp = yield this.octokit.rest.actions.createWorkflowDispatch({
                     owner: this.owner,
                     repo: this.repo,
@@ -29763,7 +29770,18 @@ class WorkflowHandler {
                 if (runs.length == 0) {
                     throw new Error('Run not found');
                 }
-                if (runs.length > 1) {
+                if (runs.length > 1 && this.dispatchedInputs && Object.keys(this.dispatchedInputs).length > 0) {
+                    core.info(`Found ${runs.length} runs. Attempting to disambiguate by matching inputs.`);
+                    const matchedRun = yield this.findRunMatchingInputs(runs);
+                    if (matchedRun) {
+                        core.info(`Matched run ${matchedRun.id} by inputs.`);
+                        this.workflowRunId = matchedRun.id;
+                        return this.workflowRunId;
+                    }
+                    core.warning(`Could not disambiguate runs by inputs. Using the last one.`);
+                    yield this.debugFoundWorkflowRuns(runs);
+                }
+                else if (runs.length > 1) {
                     core.warning(`Found ${runs.length} runs. Using the last one.`);
                     yield this.debugFoundWorkflowRuns(runs);
                 }
@@ -29775,6 +29793,38 @@ class WorkflowHandler {
                 throw error;
             }
         });
+    }
+    findRunMatchingInputs(runs) {
+        return __awaiter(this, void 0, void 0, function* () {
+            for (const run of runs) {
+                try {
+                    const response = yield this.octokit.rest.actions.getWorkflowRun({
+                        owner: this.owner,
+                        repo: this.repo,
+                        run_id: run.id
+                    });
+                    const runInputs = response.data.inputs || {};
+                    if (this.inputsMatch(runInputs)) {
+                        return run;
+                    }
+                }
+                catch (e) {
+                    core.debug(`Failed to fetch inputs for run ${run.id}: ${e.message}`);
+                }
+            }
+            return null;
+        });
+    }
+    inputsMatch(runInputs) {
+        if (!this.dispatchedInputs) {
+            return false;
+        }
+        const dispatchedKeys = Object.keys(this.dispatchedInputs);
+        const runKeys = Object.keys(runInputs);
+        if (dispatchedKeys.length === 0 || dispatchedKeys.length !== runKeys.length) {
+            return false;
+        }
+        return dispatchedKeys.every(key => runInputs[key] === this.dispatchedInputs[key]);
     }
     getWorkflowId() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -31859,7 +31909,7 @@ module.exports = parseParams
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/
+/******/ 	
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -31873,7 +31923,7 @@ module.exports = parseParams
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/
+/******/ 	
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -31882,23 +31932,23 @@ module.exports = parseParams
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/
+/******/ 	
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/
+/******/ 	
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/
+/******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/
+/******/ 	
 /************************************************************************/
-/******/
+/******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(399);
 /******/ 	module.exports = __webpack_exports__;
-/******/
+/******/ 	
 /******/ })()
 ;

--- a/.github/actions/dispatch-resume-workflow/src/workflow-handler.ts
+++ b/.github/actions/dispatch-resume-workflow/src/workflow-handler.ts
@@ -48,6 +48,7 @@ export class WorkflowHandler {
   private workflowId?: number | string
   private workflowRunId?: number
   private triggerDate = 0
+  private dispatchedInputs?: Record<string, string>
 
   constructor(token: string,
     private workflowRef: string,
@@ -67,6 +68,7 @@ export class WorkflowHandler {
     try {
       const workflowId = await this.getWorkflowId()
       this.triggerDate = new Date().setMilliseconds(0)
+      this.dispatchedInputs = inputs
       const dispatchResp = await this.octokit.rest.actions.createWorkflowDispatch({
         owner: this.owner,
         repo: this.repo,
@@ -181,7 +183,17 @@ export class WorkflowHandler {
         throw new Error('Run not found')
       }
 
-      if (runs.length > 1) {
+      if (runs.length > 1 && this.dispatchedInputs && Object.keys(this.dispatchedInputs).length > 0) {
+        core.info(`Found ${runs.length} runs. Attempting to disambiguate by matching inputs.`)
+        const matchedRun = await this.findRunMatchingInputs(runs)
+        if (matchedRun) {
+          core.info(`Matched run ${matchedRun.id} by inputs.`)
+          this.workflowRunId = matchedRun.id as number
+          return this.workflowRunId
+        }
+        core.warning(`Could not disambiguate runs by inputs. Using the last one.`)
+        await this.debugFoundWorkflowRuns(runs)
+      } else if (runs.length > 1) {
         core.warning(`Found ${runs.length} runs. Using the last one.`)
         await this.debugFoundWorkflowRuns(runs)
       }
@@ -193,6 +205,37 @@ export class WorkflowHandler {
       debug('Get workflow run id error', error)
       throw error
     }
+  }
+
+  private async findRunMatchingInputs(runs: any[]): Promise<any | null> {
+    for (const run of runs) {
+      try {
+        const response = await this.octokit.rest.actions.getWorkflowRun({
+          owner: this.owner,
+          repo: this.repo,
+          run_id: run.id
+        })
+        const runInputs = response.data.inputs || {}
+        if (this.inputsMatch(runInputs)) {
+          return run
+        }
+      } catch (e: any) {
+        core.debug(`Failed to fetch inputs for run ${run.id}: ${e.message}`)
+      }
+    }
+    return null
+  }
+
+  private inputsMatch(runInputs: Record<string, string>): boolean {
+    if (!this.dispatchedInputs) {
+      return false
+    }
+    const dispatchedKeys = Object.keys(this.dispatchedInputs)
+    const runKeys = Object.keys(runInputs)
+    if (dispatchedKeys.length === 0 || dispatchedKeys.length !== runKeys.length) {
+      return false
+    }
+    return dispatchedKeys.every(key => runInputs[key] === this.dispatchedInputs![key])
   }
 
   private async getWorkflowId(): Promise<number | string> {


### PR DESCRIPTION
## Problem

When multiple callers dispatch the same workflow simultaneously (e.g., `prod-eu` and `prod-internal` both triggering `hxp-frontend-apps/acceptance-tests.yml` in parallel), the action incorrectly identifies the triggered run.

**Root cause:** `getWorkflowRunId()` lists runs created after `triggerDate` (second-precision filter). When two dispatches occur within the same second, both finders see both runs and both pick `runs[0]` (the newest), causing one job to monitor the wrong workflow run.

**Observed in:** https://github.com/HylandSoftware/terraform-aws-hxps-environment/actions/runs/25971221208/job/76511318984 — `Production - Internal` reported run 26029500818 (belonging to `Production EU`) instead of its own run 26029499560.

## Fix

When multiple runs are found after a dispatch, the action now:
1. Fetches each run's details via `GET /repos/{owner}/{repo}/actions/runs/{run_id}`
2. Compares the run's `inputs` field against the inputs that were dispatched
3. Returns the first run whose inputs match exactly

Falls back to existing behavior (pick newest) if input matching fails or no dispatched inputs are available.

## Changes

- Store dispatched inputs in `triggerWorkflow()`
- Add `findRunMatchingInputs()` to fetch and compare run inputs
- Add `inputsMatch()` helper for key-by-key comparison
- No changes required in consuming workflows

## Testing

This is backward-compatible: if only one run is found or if inputs can't be matched, behavior is unchanged.