### PR TITLE
feat: pipenv action supports custom categories and optional dev flag

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -5,6 +5,16 @@ inputs:
     description: The python version
     required: false
     default: "3.11"
+  enable-dev:
+    description: Whether to install dev packages (--dev flag)
+    required: false
+    default: "true"
+  categories:
+    description: >-
+      Comma-separated list of additional Pipfile categories to install
+      (e.g. "lint,test"). Translates to --categories for pipenv install.
+    required: false
+    default: ""
 outputs:
   pipenv-root:
     description: >-
@@ -22,5 +32,12 @@ runs:
       id: pipenv
       shell: bash
       run: |
-        pipenv install --deploy --dev --python ${{ inputs.python-version }}
+        PIPENV_ARGS=(--deploy --python "${{ inputs.python-version }}")
+        if [[ "${{ inputs.enable-dev }}" == "true" ]]; then
+          PIPENV_ARGS+=(--dev)
+        fi
+        if [[ -n "${{ inputs.categories }}" ]]; then
+          PIPENV_ARGS+=(--categories="${{ inputs.categories }}")
+        fi
+        pipenv install "${PIPENV_ARGS[@]}"
         echo "pipenv-root=$(pwd)" >> $GITHUB_OUTPUT

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,12 +49,15 @@ Brief description of what the action does.
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/action-name@ref
         with:
-          parameter: value
+          required-parameter: value
+          optional-parameter: value  # optional, default: default-value
 ```
 
 Additional notes or configuration details.
 
 **Note**: Always replace `@ref` with the most recent released tag (e.g., `@v9.1.0`).
+
+Input tables are not necessary — a YAML snippet with inline comments is sufficient to document inputs and their defaults.
 
 **Run validation script** to ensure all actions are documented:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1920,6 +1920,8 @@ This workflow sets up a Python environment using the standard setup-python actio
       - uses: Alfresco/alfresco-build-tools/.github/actions/pipenv@v18.1.0
         with:
           python-version: ${{ steps.setup-python.outputs.python-version }}
+          enable-dev: "true"       # optional, default: true
+          categories: "lint,test"  # optional, comma-separated custom Pipfile categories
 ```
 
 > This action returns the root directory where pipenv was installed from (so it can be used to build the PIPENV_PIPFILE env var)


### PR DESCRIPTION
## Summary

Add support for custom Pipfile categories and optional dev packages installation in the `pipenv` action.

### Changes
- **`categories`** input: comma-separated list of Pipfile categories, passed as `--categories="..."` to `pipenv install`
- **`enable-dev`** input (default: `true`): controls whether `--dev` is passed — preserves backward compatibility
- Use bash array instead of `eval` for safe argument passing
- Updated `docs/README.md` with inline-commented snippet (no input table)
- Updated `copilot-instructions.md` to prefer inline comments over input tables in docs

### Backward compatibility
Default behavior is unchanged: `enable-dev` defaults to `true`, `categories` defaults to empty.