### PR TITLE
AAE-45986 Disambiguate concurrent dispatches using run-name suffix match

### DIFF
--- a/.github/actions/dispatch-resume-workflow/action.yml
+++ b/.github/actions/dispatch-resume-workflow/action.yml
@@ -18,7 +18,10 @@ inputs:
     description: 'Repo owner & name, slash separated, only set if invoking a workflow in a different repo'
     required: false
   run-name:
-    description: 'If specified will select the run ID based on the run name'
+    description: 'If specified will select the run ID based on the run name (exact match)'
+    required: false
+  run-name-contains:
+    description: 'If specified will disambiguate runs by matching this value as a suffix of the run name (endsWith match)'
     required: false
   run-id:
     description: 'If specified will select the run ID on existing workflow'

--- a/.github/actions/dispatch-resume-workflow/dist/index.js
+++ b/.github/actions/dispatch-resume-workflow/dist/index.js
@@ -29382,7 +29382,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const args = (0, utils_1.getArgs)();
-            const workflowHandler = new workflow_handler_1.WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.runId);
+            const workflowHandler = new workflow_handler_1.WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.runNameContains, args.runId);
             if (args.runId) {
                 core.info(`Using existing workflow run ID: ${args.runId}`);
                 let conclusion;
@@ -29512,6 +29512,7 @@ function getArgs() {
     const waitForCompletionTimeout = toMilliseconds(core.getInput('wait-for-completion-timeout'));
     const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'));
     const runName = core.getInput('run-name');
+    const runNameContains = core.getInput('run-name-contains');
     const runId = core.getInput('run-id');
     const workflowLogMode = core.getInput('workflow-logs');
     return {
@@ -29528,6 +29529,7 @@ function getArgs() {
         waitForCompletion,
         waitForCompletionTimeout,
         runName,
+        runNameContains,
         runId,
         workflowLogMode
     };
@@ -29638,12 +29640,13 @@ const ofConclusion = (conclusion) => {
     return WorkflowRunConclusion[key];
 };
 class WorkflowHandler {
-    constructor(token, workflowRef, owner, repo, ref, runName, runId) {
+    constructor(token, workflowRef, owner, repo, ref, runName, runNameContains, runId) {
         this.workflowRef = workflowRef;
         this.owner = owner;
         this.repo = repo;
         this.ref = ref;
         this.runName = runName;
+        this.runNameContains = runNameContains;
         this.runId = runId;
         this.triggerDate = 0;
         if (runId) {
@@ -29657,7 +29660,6 @@ class WorkflowHandler {
             try {
                 const workflowId = yield this.getWorkflowId();
                 this.triggerDate = new Date().setMilliseconds(0);
-                this.dispatchedInputs = inputs;
                 const dispatchResp = yield this.octokit.rest.actions.createWorkflowDispatch({
                     owner: this.owner,
                     repo: this.repo,
@@ -29764,24 +29766,27 @@ class WorkflowHandler {
             }
             try {
                 let runs = yield this.findAllWorkflowRuns();
+                core.info(`Found ${runs.length} workflow run(s) matching criteria.`);
+                runs.forEach((r) => core.info(`  - run ${r.id}: "${r.name}"`));
                 if (this.runName) {
-                    runs = runs.filter((r) => r.name == this.runName);
+                    core.info(`Filtering by exact run-name: "${this.runName}"`);
+                    runs = runs.filter((r) => r.name === this.runName);
+                    core.info(`  ${runs.length} run(s) after filtering.`);
                 }
                 if (runs.length == 0) {
                     throw new Error('Run not found');
                 }
-                if (runs.length > 1 && this.dispatchedInputs && Object.keys(this.dispatchedInputs).length > 0) {
-                    core.info(`Found ${runs.length} runs. Attempting to disambiguate by matching inputs.`);
-                    const matchedRun = yield this.findRunMatchingInputs(runs);
-                    if (matchedRun) {
-                        core.info(`Matched run ${matchedRun.id} by inputs.`);
-                        this.workflowRunId = matchedRun.id;
+                if (runs.length > 1 && this.runNameContains) {
+                    core.info(`Attempting to disambiguate ${runs.length} runs using run-name-contains="${this.runNameContains}" (endsWith)`);
+                    const filtered = runs.filter((r) => { var _a; return (_a = r.name) === null || _a === void 0 ? void 0 : _a.endsWith(this.runNameContains); });
+                    if (filtered.length === 1) {
+                        core.info(`Disambiguated: matched run ${filtered[0].id} ("${filtered[0].name}")`);
+                        this.workflowRunId = filtered[0].id;
                         return this.workflowRunId;
                     }
-                    core.warning(`Could not disambiguate runs by inputs. Using the last one.`);
-                    yield this.debugFoundWorkflowRuns(runs);
+                    core.warning(`run-name-contains="${this.runNameContains}" matched ${filtered.length} runs, falling back.`);
                 }
-                else if (runs.length > 1) {
+                if (runs.length > 1) {
                     core.warning(`Found ${runs.length} runs. Using the last one.`);
                     yield this.debugFoundWorkflowRuns(runs);
                 }
@@ -29793,38 +29798,6 @@ class WorkflowHandler {
                 throw error;
             }
         });
-    }
-    findRunMatchingInputs(runs) {
-        return __awaiter(this, void 0, void 0, function* () {
-            for (const run of runs) {
-                try {
-                    const response = yield this.octokit.rest.actions.getWorkflowRun({
-                        owner: this.owner,
-                        repo: this.repo,
-                        run_id: run.id
-                    });
-                    const runInputs = response.data.inputs || {};
-                    if (this.inputsMatch(runInputs)) {
-                        return run;
-                    }
-                }
-                catch (e) {
-                    core.debug(`Failed to fetch inputs for run ${run.id}: ${e.message}`);
-                }
-            }
-            return null;
-        });
-    }
-    inputsMatch(runInputs) {
-        if (!this.dispatchedInputs) {
-            return false;
-        }
-        const dispatchedKeys = Object.keys(this.dispatchedInputs);
-        const runKeys = Object.keys(runInputs);
-        if (dispatchedKeys.length === 0 || dispatchedKeys.length !== runKeys.length) {
-            return false;
-        }
-        return dispatchedKeys.every(key => runInputs[key] === this.dispatchedInputs[key]);
     }
     getWorkflowId() {
         return __awaiter(this, void 0, void 0, function* () {

--- a/.github/actions/dispatch-resume-workflow/src/main.ts
+++ b/.github/actions/dispatch-resume-workflow/src/main.ts
@@ -75,7 +75,7 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
 async function run(): Promise<void> {
   try {
     const args = getArgs()
-    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.runId)
+    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.runNameContains, args.runId)
 
     if (args.runId) {
       core.info(`Using existing workflow run ID: ${args.runId}`)

--- a/.github/actions/dispatch-resume-workflow/src/utils.ts
+++ b/.github/actions/dispatch-resume-workflow/src/utils.ts
@@ -50,6 +50,7 @@ export function getArgs() {
   const waitForCompletionTimeout = toMilliseconds(core.getInput('wait-for-completion-timeout'))
   const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'))
   const runName = core.getInput('run-name')
+  const runNameContains = core.getInput('run-name-contains')
   const runId = core.getInput('run-id')
   const workflowLogMode = core.getInput('workflow-logs')
 
@@ -67,6 +68,7 @@ export function getArgs() {
     waitForCompletion,
     waitForCompletionTimeout,
     runName,
+    runNameContains,
     runId,
     workflowLogMode
   }

--- a/.github/actions/dispatch-resume-workflow/src/workflow-handler.ts
+++ b/.github/actions/dispatch-resume-workflow/src/workflow-handler.ts
@@ -48,7 +48,6 @@ export class WorkflowHandler {
   private workflowId?: number | string
   private workflowRunId?: number
   private triggerDate = 0
-  private dispatchedInputs?: Record<string, string>
 
   constructor(token: string,
     private workflowRef: string,
@@ -56,6 +55,7 @@ export class WorkflowHandler {
     private repo: string,
     private ref: string,
     private runName: string,
+    private runNameContains: string,
     private runId: string) {
     if (runId) {
       this.workflowRunId = parseInt(runId)
@@ -68,7 +68,6 @@ export class WorkflowHandler {
     try {
       const workflowId = await this.getWorkflowId()
       this.triggerDate = new Date().setMilliseconds(0)
-      this.dispatchedInputs = inputs
       const dispatchResp = await this.octokit.rest.actions.createWorkflowDispatch({
         owner: this.owner,
         repo: this.repo,
@@ -175,25 +174,31 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
+      core.info(`Found ${runs.length} workflow run(s) matching criteria.`)
+      runs.forEach((r: any) => core.info(`  - run ${r.id}: "${r.name}"`))
+
       if (this.runName) {
-        runs = runs.filter((r: any) => r.name == this.runName)
+        core.info(`Filtering by exact run-name: "${this.runName}"`)
+        runs = runs.filter((r: any) => r.name === this.runName)
+        core.info(`  ${runs.length} run(s) after filtering.`)
       }
 
       if (runs.length == 0) {
         throw new Error('Run not found')
       }
 
-      if (runs.length > 1 && this.dispatchedInputs && Object.keys(this.dispatchedInputs).length > 0) {
-        core.info(`Found ${runs.length} runs. Attempting to disambiguate by matching inputs.`)
-        const matchedRun = await this.findRunMatchingInputs(runs)
-        if (matchedRun) {
-          core.info(`Matched run ${matchedRun.id} by inputs.`)
-          this.workflowRunId = matchedRun.id as number
+      if (runs.length > 1 && this.runNameContains) {
+        core.info(`Attempting to disambiguate ${runs.length} runs using run-name-contains="${this.runNameContains}" (endsWith)`)
+        const filtered = runs.filter((r: any) => r.name?.endsWith(this.runNameContains))
+        if (filtered.length === 1) {
+          core.info(`Disambiguated: matched run ${filtered[0].id} ("${filtered[0].name}")`)
+          this.workflowRunId = filtered[0].id as number
           return this.workflowRunId
         }
-        core.warning(`Could not disambiguate runs by inputs. Using the last one.`)
-        await this.debugFoundWorkflowRuns(runs)
-      } else if (runs.length > 1) {
+        core.warning(`run-name-contains="${this.runNameContains}" matched ${filtered.length} runs, falling back.`)
+      }
+
+      if (runs.length > 1) {
         core.warning(`Found ${runs.length} runs. Using the last one.`)
         await this.debugFoundWorkflowRuns(runs)
       }
@@ -205,37 +210,6 @@ export class WorkflowHandler {
       debug('Get workflow run id error', error)
       throw error
     }
-  }
-
-  private async findRunMatchingInputs(runs: any[]): Promise<any | null> {
-    for (const run of runs) {
-      try {
-        const response = await this.octokit.rest.actions.getWorkflowRun({
-          owner: this.owner,
-          repo: this.repo,
-          run_id: run.id
-        })
-        const runInputs = response.data.inputs || {}
-        if (this.inputsMatch(runInputs)) {
-          return run
-        }
-      } catch (e: any) {
-        core.debug(`Failed to fetch inputs for run ${run.id}: ${e.message}`)
-      }
-    }
-    return null
-  }
-
-  private inputsMatch(runInputs: Record<string, string>): boolean {
-    if (!this.dispatchedInputs) {
-      return false
-    }
-    const dispatchedKeys = Object.keys(this.dispatchedInputs)
-    const runKeys = Object.keys(runInputs)
-    if (dispatchedKeys.length === 0 || dispatchedKeys.length !== runKeys.length) {
-      return false
-    }
-    return dispatchedKeys.every(key => runInputs[key] === this.dispatchedInputs![key])
   }
 
   private async getWorkflowId(): Promise<number | string> {

--- a/docs/README.md
+++ b/docs/README.md
@@ -528,8 +528,15 @@ Ability to dispatch or resume an existing workflow and wait for its completion.
       - uses: Alfresco/alfresco-build-tools/.github/actions/dispatch-resume-workflow@v18.2.0
         with:
           workflow: workflow-name.yml
-          run-id: existing_run_number (optional)
+          run-id: existing_run_number # optional, resume an existing run
+          run-name: "exact run name" # optional, filter by exact run name
+          run-name-contains: "suffix" # optional, disambiguate by run name suffix (endsWith match)
 ```
+
+When multiple concurrent dispatches target the same workflow (e.g. parallel deployments to different environments),
+use `run-name-contains` to pick the correct run. It matches using `endsWith` to avoid substring collisions.
+For example, with runs named `Tests on env-prod` and `Tests on env-prod-au`, passing
+`run-name-contains: env-prod` uniquely selects the first run (not the `-au` variant).
 
 ### docker-dump-containers-logs
 


### PR DESCRIPTION
## Summary

Replace the broken input-matching disambiguation with a new `run-name-contains` input that uses `endsWith` to reliably pick the correct workflow run when multiple concurrent dispatches target the same workflow.

## Problem

The previous approach (from #1407) attempted to disambiguate runs by matching dispatched inputs against the workflow run's inputs from the GitHub API. However, **the GitHub REST API does not return `inputs` on the workflow run response** — the field is always absent/null. This made the disambiguation always fail with:

```
Found 2 runs. Attempting to disambiguate by matching inputs.
Warning: Could not disambiguate runs by inputs. Using the last one.
```

## Solution

Added a new `run-name-contains` action input that disambiguates by matching the **suffix** of the workflow run name. For example, when two concurrent runs exist:
- `🎭 Studio user acceptance tests on hxp-canary-prod`
- `🎭 Studio user acceptance tests on hxp-canary-prod-au`

Passing `run-name-contains: hxp-canary-prod-au` uniquely identifies the second run using `endsWith`.

### Usage

```yaml
- uses: Alfresco/alfresco-build-tools/.github/actions/dispatch-resume-workflow@ref
  with:
    workflow: acceptance-tests.yml
    repo: Alfresco/hxp-studio-services
    run-name-contains: hxp-canary-prod-au
    inputs: '{"environment": "hxp-canary-prod-au"}'
```

## Changes

- Added `run-name-contains` input to `action.yml`
- Disambiguation uses `endsWith` (not `includes`) to avoid substring collisions (e.g. `prod` matching `prod-au`)
- Removed dead `dispatchedInputs` / `findRunMatchingInputs` / `inputsMatch` code (GitHub API never returns inputs)
