### PR TITLE
AAE-46385 Add pre-commit hook to report on compilation status for GH AWs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,23 +200,12 @@ GitHub Agentic Workflows (AWF) are markdown-based workflows that use AI agents (
 ### Development Workflow
 
 1. **Edit the `.md` file** - Modify the workflow instructions in plain markdown
-2. **Pre-commit hook auto-compiles** - The `compile-agentic-workflows` hook automatically:
-   - Upgrades the `gh aw` extension to the latest version
-   - Compiles the `.md` file to generate the `.lock.yml` file
-   - Stages all generated files (`.lock.yml`, `.github/aw/`, `.gitattributes`, `dependabot.yml`)
-3. **Commit both files** - Both `.md` and `.lock.yml` are committed together
+2. **Compile the workflow** - Run the compilation command:
 
-### Manual Compilation (if needed)
-
-If you need to manually compile (e.g., pre-commit hook disabled):
-
-```bash
-# Upgrade gh aw extension
-gh extension upgrade aw
-
-# Compile the workflow
-gh aw compile .github/workflows/workflow-name.md
-```
+   ```bash
+   gh extension upgrade aw # Ensure you have the latest version of the gh aw extension
+   gh aw compile .github/workflows/workflow-name.md
+   ```
 
 ### Important Notes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -203,8 +203,9 @@ GitHub Agentic Workflows (AWF) are markdown-based workflows that use AI agents (
 2. **Compile the workflow** - Run the compilation command:
 
    ```bash
-   gh extension upgrade aw # Ensure you have the latest version of the gh aw extension
-   gh aw compile .github/workflows/workflow-name.md
+   gh extension install github/gh-aw # Only the first time
+   gh extension upgrade aw # Ensure you always have the latest version of the gh aw extension
+   gh aw compile .github/workflows/workflow-name.md # Always compile the affected workflows
    ```
 
 ### Important Notes
@@ -212,7 +213,7 @@ GitHub Agentic Workflows (AWF) are markdown-based workflows that use AI agents (
 - **Never edit `.lock.yml` files directly** - They are generated from the `.md` source
 - **Always commit both `.md` and `.lock.yml` together** - They must stay in sync
 - **The `.md` file is the source of truth** - All edits go there
-- **Pre-commit hook handles compilation automatically** - No manual steps needed
+- **Pre-commit hook handles compilation reminders** - Compilation may be required unless editing only the prompt
 - **Lock files are excluded from most linters** - They have special syntax that doesn't follow normal YAML/markdown rules
 
 ## Common Pitfalls to Avoid

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -193,6 +193,39 @@ For common operations:
 - Reusable across different workflows
 - Well-documented inputs/outputs
 
+## GitHub Agentic Workflows
+
+GitHub Agentic Workflows (AWF) are markdown-based workflows that use AI agents (like GitHub Copilot) to perform complex reasoning tasks. This repository provides agentic workflows in `.github/workflows/*.md` files.
+
+### Development Workflow
+
+1. **Edit the `.md` file** - Modify the workflow instructions in plain markdown
+2. **Pre-commit hook auto-compiles** - The `compile-agentic-workflows` hook automatically:
+   - Upgrades the `gh aw` extension to the latest version
+   - Compiles the `.md` file to generate the `.lock.yml` file
+   - Stages all generated files (`.lock.yml`, `.github/aw/`, `.gitattributes`, `dependabot.yml`)
+3. **Commit both files** - Both `.md` and `.lock.yml` are committed together
+
+### Manual Compilation (if needed)
+
+If you need to manually compile (e.g., pre-commit hook disabled):
+
+```bash
+# Upgrade gh aw extension
+gh extension upgrade aw
+
+# Compile the workflow
+gh aw compile .github/workflows/workflow-name.md
+```
+
+### Important Notes
+
+- **Never edit `.lock.yml` files directly** - They are generated from the `.md` source
+- **Always commit both `.md` and `.lock.yml` together** - They must stay in sync
+- **The `.md` file is the source of truth** - All edits go there
+- **Pre-commit hook handles compilation automatically** - No manual steps needed
+- **Lock files are excluded from most linters** - They have special syntax that doesn't follow normal YAML/markdown rules
+
 ## Common Pitfalls to Avoid
 
 - **Never** skip version bumping for functional changes

--- a/.github/scripts/compile_agentic_workflows.sh
+++ b/.github/scripts/compile_agentic_workflows.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 set -e
 
-# Pre-commit hook to auto-compile GitHub Agentic Workflow .md files
-# This hook ensures that .lock.yml files are kept in sync with .md sources
+# Pre-commit hook to ensure agentic workflow .lock.yml files are in sync
+# Compiles .md files and compares frontmatter hash to detect drift
 
-# Find all .md files in .github/workflows/ that are staged
-md_files=$(git diff --cached --name-only --diff-filter=ACM | grep '^\.github/workflows/.*\.md$' || true)
+# Get list of .md files in .github/workflows/
+md_files=$(find .github/workflows -name "*.md" -type f 2>/dev/null || true)
 
 if [ -z "$md_files" ]; then
-    # No agentic workflow files modified, exit silently
     exit 0
 fi
 
-echo "Compiling agentic workflows..."
+# Filter to only agentic workflows
+aw_files=""
+for md_file in $md_files; do
+    if head -n 20 "$md_file" | grep -q "^on:$\|^engine:$"; then
+        aw_files="$aw_files $md_file"
+    fi
+done
+
+if [ -z "$aw_files" ]; then
+    exit 0
+fi
+
+echo "Validating agentic workflow compilation..."
 
 # Check if gh aw extension is installed
 if ! gh extension list 2>/dev/null | grep -q "gh-aw"; then
@@ -21,36 +32,56 @@ if ! gh extension list 2>/dev/null | grep -q "gh-aw"; then
     exit 1
 fi
 
-# Get current version for reference
-current_version=$(gh extension list 2>/dev/null | grep gh-aw | awk '{print $3}' || echo "unknown")
+needs_recompile=false
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
 
-# Upgrade gh aw extension to latest version (suppress output unless there's an error)
-if ! gh extension upgrade aw >/dev/null 2>&1; then
-    echo "⚠ Warning: Failed to upgrade gh aw extension, using version $current_version"
-fi
-
-# Compile all modified .md files
-for md_file in $md_files; do
-    echo "  Compiling $(basename "$md_file")..."
-
-    # Run compilation
-    if ! gh aw compile "$md_file" >/dev/null 2>&1; then
-        echo "✗ Error: Failed to compile $md_file"
-        gh aw compile "$md_file" 2>&1 | head -20  # Show error details
-        exit 1
-    fi
-
-    # Stage the generated .lock.yml file
+for md_file in $aw_files; do
     lock_file="${md_file%.md}.lock.yml"
-    if [ -f "$lock_file" ]; then
-        git add "$lock_file"
+
+    echo "  Checking $(basename "$md_file")..."
+
+    # Check if lock file exists
+    if [ ! -f "$lock_file" ]; then
+        echo "    ✗ Missing lock file"
+        needs_recompile=true
+        continue
     fi
 
-    # Also stage any other generated files
-    [ -f ".github/aw/actions-lock.json" ] && git add ".github/aw/actions-lock.json"
-    [ -f ".gitattributes" ] && git add ".gitattributes"
-    [ -f ".github/dependabot.yml" ] && git add ".github/dependabot.yml"
+    # Compile in temp directory
+    temp_md="$temp_dir/$(basename "$md_file")"
+    cp "$md_file" "$temp_md"
+
+    if ! (cd "$temp_dir" && gh aw compile "$(basename "$md_file")" >/dev/null 2>&1); then
+        echo "    ✗ Compilation failed"
+        needs_recompile=true
+        continue
+    fi
+
+    # Extract frontmatter hash from both lock files
+    current_hash=$(grep "^# gh-aw-metadata:" "$lock_file" | sed 's/.*"frontmatter_hash":"\([^"]*\)".*/\1/' || echo "none")
+    new_hash=$(grep "^# gh-aw-metadata:" "$temp_dir/$(basename "$lock_file")" | sed 's/.*"frontmatter_hash":"\([^"]*\)".*/\1/' || echo "none")
+
+    if [ "$current_hash" != "$new_hash" ]; then
+        echo "    ✗ Lock file out of sync (frontmatter changed)"
+        needs_recompile=true
+    else
+        echo "    ✓ In sync"
+    fi
 done
 
-echo "✓ Compilation complete"
+if [ "$needs_recompile" = true ]; then
+    echo ""
+    echo "════════════════════════════════════════════════════════════════"
+    echo "  Agentic workflow needs recompilation"
+    echo "════════════════════════════════════════════════════════════════"
+    echo ""
+    echo "Run: gh extension upgrade aw && gh aw compile .github/workflows/<workflow-name>.md"
+    echo ""
+    echo "Then stage: git add .github/workflows/*.lock.yml .github/aw/"
+    echo ""
+    exit 1
+fi
+
+echo "✓ All agentic workflows in sync"
 exit 0

--- a/.github/scripts/compile_agentic_workflows.sh
+++ b/.github/scripts/compile_agentic_workflows.sh
@@ -27,9 +27,20 @@ echo "Validating agentic workflow compilation..."
 
 # Check if gh aw extension is installed
 if ! gh extension list 2>/dev/null | grep -q "gh-aw"; then
-    echo "✗ Error: gh aw extension is not installed"
-    echo "  Install it with: gh extension install github/gh-aw"
-    exit 1
+    # In CI, auto-install the extension
+    if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
+        echo "  Installing gh aw extension in CI..."
+        if ! gh extension install github/gh-aw >/dev/null 2>&1; then
+            echo "✗ Error: Failed to install gh aw extension"
+            exit 1
+        fi
+        echo "  ✓ Installed gh aw extension"
+    else
+        # In local environment, prompt user to install
+        echo "✗ Error: gh aw extension is not installed"
+        echo "  Install it with: gh extension install github/gh-aw"
+        exit 1
+    fi
 fi
 
 needs_recompile=false

--- a/.github/scripts/compile_agentic_workflows.sh
+++ b/.github/scripts/compile_agentic_workflows.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Pre-commit hook to auto-compile GitHub Agentic Workflow .md files
+# This hook ensures that .lock.yml files are kept in sync with .md sources
+
+# Find all .md files in .github/workflows/ that are staged
+md_files=$(git diff --cached --name-only --diff-filter=ACM | grep '^\.github/workflows/.*\.md$' || true)
+
+if [ -z "$md_files" ]; then
+    # No agentic workflow files modified, exit silently
+    exit 0
+fi
+
+echo "Compiling agentic workflows..."
+
+# Check if gh aw extension is installed
+if ! gh extension list 2>/dev/null | grep -q "gh-aw"; then
+    echo "✗ Error: gh aw extension is not installed"
+    echo "  Install it with: gh extension install github/gh-aw"
+    exit 1
+fi
+
+# Get current version for reference
+current_version=$(gh extension list 2>/dev/null | grep gh-aw | awk '{print $3}' || echo "unknown")
+
+# Upgrade gh aw extension to latest version (suppress output unless there's an error)
+if ! gh extension upgrade aw >/dev/null 2>&1; then
+    echo "⚠ Warning: Failed to upgrade gh aw extension, using version $current_version"
+fi
+
+# Compile all modified .md files
+for md_file in $md_files; do
+    echo "  Compiling $(basename "$md_file")..."
+
+    # Run compilation
+    if ! gh aw compile "$md_file" >/dev/null 2>&1; then
+        echo "✗ Error: Failed to compile $md_file"
+        gh aw compile "$md_file" 2>&1 | head -20  # Show error details
+        exit 1
+    fi
+
+    # Stage the generated .lock.yml file
+    lock_file="${md_file%.md}.lock.yml"
+    if [ -f "$lock_file" ]; then
+        git add "$lock_file"
+    fi
+
+    # Also stage any other generated files
+    [ -f ".github/aw/actions-lock.json" ] && git add ".github/aw/actions-lock.json"
+    [ -f ".gitattributes" ] && git add ".gitattributes"
+    [ -f ".github/dependabot.yml" ] && git add ".github/dependabot.yml"
+done
+
+echo "✓ Compilation complete"
+exit 0

--- a/.github/workflows/supply-chain-review.md
+++ b/.github/workflows/supply-chain-review.md
@@ -24,7 +24,6 @@ network:
     - api.osv.dev
     - api.scorecard.dev
     - search.maven.org
-    - registry.npmjs.org
 
 safe-outputs:
   add-comment:

--- a/.github/workflows/supply-chain-review.md
+++ b/.github/workflows/supply-chain-review.md
@@ -342,5 +342,3 @@ No suspicious patterns detected. Routine upgrade.
 - If data collection fails for all external APIs, still analyze the PR diff directly and provide the best assessment you can with available information, noting the limitations clearly.
 - For tag poisoning checks, not all packages will have provenance attestations — this is still an emerging practice. Weight the absence of attestations proportionally to the package's profile and criticality. Do not flag low-download utility packages for missing provenance.
 - When checking tag dates, allow for reasonable CI/CD pipeline delays (up to a few hours between tag push and publish). Only flag significant discrepancies (days or weeks).
-
-Test MD change just prompt.

--- a/.github/workflows/supply-chain-review.md
+++ b/.github/workflows/supply-chain-review.md
@@ -24,6 +24,7 @@ network:
     - api.osv.dev
     - api.scorecard.dev
     - search.maven.org
+    - registry.npmjs.org
 
 safe-outputs:
   add-comment:

--- a/.github/workflows/supply-chain-review.md
+++ b/.github/workflows/supply-chain-review.md
@@ -341,3 +341,5 @@ No suspicious patterns detected. Routine upgrade.
 - If data collection fails for all external APIs, still analyze the PR diff directly and provide the best assessment you can with available information, noting the limitations clearly.
 - For tag poisoning checks, not all packages will have provenance attestations — this is still an emerging practice. Weight the absence of attestations proportionally to the package's profile and criticality. Do not flag low-download utility packages for missing provenance.
 - When checking tag dates, allow for reasonable CI/CD pipeline delays (up to a few hours between tag push and publish). Only flag significant discrepancies (days or weeks).
+
+Test MD change just prompt.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
   - repo: local
     hooks:
       - id: compile-agentic-workflows
-        name: Compile GitHub Agentic Workflows
+        name: Validate GitHub Agentic Workflow compilation
         language: system
         entry: .github/scripts/compile_agentic_workflows.sh
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: compile-agentic-workflows
+        name: Compile GitHub Agentic Workflows
+        language: system
+        entry: .github/scripts/compile_agentic_workflows.sh
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.md$
+        stages: [pre-commit]
+
       - id: check-action-nesting-depth
         name: Check GitHub Actions nesting depth
         language: python


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): AAE-46385
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->

Adding a pre-commit hook to issue errors in case GH AWs are out of sync with their expected compiled variant.

**Test without any GH AW changes**: https://github.com/Alfresco/alfresco-build-tools/actions/runs/26584127450/job/78325203563?pr=1416 ✅ 
**Test with just changing the prompt _(does not need recompilation / lock file will be the same)_**: https://github.com/Alfresco/alfresco-build-tools/actions/runs/26584405248/job/78326237941?pr=1416 ✅ 
**Test changing the GH AW frontmatter in the md file _(needs recompilation)_**: https://github.com/Alfresco/alfresco-build-tools/actions/runs/26584504075/job/78326596113?pr=1416 ❌ 

Example failure:

```txt
Validate GitHub Agentic Workflow compilation..................................Failed
- hook id: compile-agentic-workflows
- exit code: 1
Validating agentic workflow compilation...
  Installing gh aw extension in CI...
  ✓ Installed gh aw extension
  Checking supply-chain-review.md...
    ✗ Lock file out of sync (frontmatter changed)
════════════════════════════════════════════════════════════════
  Agentic workflow needs recompilation
════════════════════════════════════════════════════════════════
Run: gh extension upgrade aw && gh aw compile .github/workflows/<workflow-name>.md
Then stage: git add .github/workflows/*.lock.yml .github/aw/
```
