### PR TITLE
AAE-46783: Sign jx-updatebot propagation commits

### DIFF
--- a/.github/actions/automate-propagation/action.yml
+++ b/.github/actions/automate-propagation/action.yml
@@ -9,9 +9,12 @@ inputs:
   approval-token:
     description: >
       Token used to approve.
-      This token CANNOT be the `BOT_GITHUB_TOKEN` secret, because it's linked to alfresco-build user (who created the PR).
+      This token CANNOT be the `BOT_GITHUB_TOKEN` secret, because it's linked to the user who created the PR.
       The default `GITHUB_TOKEN` can be used in this case.
     required: true
+  pr-author-login:
+    description: GitHub login of the user that creates propagation PRs
+    required: false
   merge-option:
     description: 'Merge option'
     required: false
@@ -25,9 +28,10 @@ runs:
       env:
         LABEL: ${{ github.event.label.name }}
         PR_LOGIN: ${{ github.event.pull_request.user.login }}
+        PR_AUTHOR_LOGIN: ${{ inputs.pr-author-login }}
       shell: bash
       run: |
-        if [[ $LABEL == 'updatebot' && $PR_LOGIN == 'alfresco-build' ]]
+        if [[ $LABEL == 'updatebot' && ( $PR_LOGIN == "$PR_AUTHOR_LOGIN" || $PR_LOGIN == 'alfresco-build' ) ]]
         then
             echo "continue=true" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/automate-propagation/action.yml
+++ b/.github/actions/automate-propagation/action.yml
@@ -31,7 +31,7 @@ runs:
         PR_AUTHOR_LOGIN: ${{ inputs.pr-author-login }}
       shell: bash
       run: |
-        if [[ $LABEL == 'updatebot' && ( $PR_LOGIN == "$PR_AUTHOR_LOGIN" || $PR_LOGIN == 'alfresco-build' ) ]]
+        if [[ "${LABEL:-}" == 'updatebot' && ( "${PR_LOGIN:-}" == "${PR_AUTHOR_LOGIN:-}" || "${PR_LOGIN:-}" == 'alfresco-build' ) ]]
         then
             echo "continue=true" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/jx-updatebot-pr/action.yml
+++ b/.github/actions/jx-updatebot-pr/action.yml
@@ -98,6 +98,10 @@ runs:
     - name: Run jx-updatebot
       run: |
         if [[ -n "$GPG_PRIVATE_KEY" ]]; then
+          if [[ -z "$GPG_PRIVATE_KEY_FINGERPRINT" ]]; then
+            echo "gpg-private-key-fingerprint must be set when gpg-private-key is provided" >&2
+            exit 1
+          fi
           GNUPGHOME=$(mktemp -d)
           chmod 700 "$GNUPGHOME"
           export GNUPGHOME

--- a/.github/actions/jx-updatebot-pr/action.yml
+++ b/.github/actions/jx-updatebot-pr/action.yml
@@ -70,6 +70,14 @@ inputs:
     description: the user email to git commit
     required: false
     default: ''
+  gpg-private-key:
+    description: ASCII-armored GPG private key for commit signing
+    required: false
+    default: ''
+  gpg-private-key-fingerprint:
+    description: 40-char GPG fingerprint of the signing key
+    required: false
+    default: ''
   jx-updatebot-release:
     description: the version of jx-updatebot release binary.
     required: false
@@ -87,6 +95,14 @@ runs:
         sudo mv jx-updatebot /usr/local/bin
       shell: bash
       working-directory: /tmp
+    - name: Setup commit signing
+      if: inputs.gpg-private-key != ''
+      uses: Alfresco/automate-build-tools/.github/actions/setup-commit-signing@45f203f0347f6eace4813dbaa3031055b3d5b9cd # v4.12.0
+      with:
+        gpg-private-key: ${{ inputs.gpg-private-key }}
+        gpg-private-key-fingerprint: ${{ inputs.gpg-private-key-fingerprint }}
+        git-user-name: ${{ inputs.git-author-name }}
+        git-user-email: ${{ inputs.git-author-email }}
     - name: Run jx-updatebot
       run: >
         jx-updatebot pr

--- a/.github/actions/jx-updatebot-pr/action.yml
+++ b/.github/actions/jx-updatebot-pr/action.yml
@@ -95,32 +95,35 @@ runs:
         sudo mv jx-updatebot /usr/local/bin
       shell: bash
       working-directory: /tmp
-    - name: Setup commit signing
-      if: inputs.gpg-private-key != ''
-      uses: Alfresco/automate-build-tools/.github/actions/setup-commit-signing@45f203f0347f6eace4813dbaa3031055b3d5b9cd # v4.12.0
-      with:
-        gpg-private-key: ${{ inputs.gpg-private-key }}
-        gpg-private-key-fingerprint: ${{ inputs.gpg-private-key-fingerprint }}
-        git-user-name: ${{ inputs.git-author-name }}
-        git-user-email: ${{ inputs.git-author-email }}
     - name: Run jx-updatebot
-      run: >
-        jx-updatebot pr
-        --auto-merge=${{ inputs.auto-merge }}
-        --version='${{ inputs.version }}'
-        --pull-request-title='${{ inputs.pull-request-title }}'
-        --pull-request-body="${{ inputs.pull-request-body }}"
-        --commit-title='${{ inputs.commit-title }}'
-        --commit-message="${{ inputs.commit-message }}"
-        --labels='${{ inputs.labels }}'
-        --base-branch-name='${{ inputs.base-branch-name }}'
-        --config-file='${{ inputs.config-file }}'
-        --version-file='${{ inputs.version-file }}'
-        --dir='${{ inputs.dir }}'
-        ${{ inputs.flags }}
+      run: |
+        if [[ -n "$GPG_PRIVATE_KEY" ]]; then
+          GNUPGHOME=$(mktemp -d)
+          chmod 700 "$GNUPGHOME"
+          export GNUPGHOME
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
+          git config --global user.signingkey "$GPG_PRIVATE_KEY_FINGERPRINT"
+          git config --global commit.gpgsign true
+        fi
+
+        jx-updatebot pr \
+          --auto-merge=${{ inputs.auto-merge }} \
+          --version='${{ inputs.version }}' \
+          --pull-request-title='${{ inputs.pull-request-title }}' \
+          --pull-request-body="${{ inputs.pull-request-body }}" \
+          --commit-title='${{ inputs.commit-title }}' \
+          --commit-message="${{ inputs.commit-message }}" \
+          --labels='${{ inputs.labels }}' \
+          --base-branch-name='${{ inputs.base-branch-name }}' \
+          --config-file='${{ inputs.config-file }}' \
+          --version-file='${{ inputs.version-file }}' \
+          --dir='${{ inputs.dir }}' \
+          ${{ inputs.flags }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+        GPG_PRIVATE_KEY_FINGERPRINT: ${{ inputs.gpg-private-key-fingerprint }}
         GIT_USERNAME: ${{ inputs.git-username }}
         GIT_TOKEN: ${{ inputs.git-token }}
         GIT_AUTHOR_NAME: ${{ inputs.git-author-name }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1629,7 +1629,7 @@ This action will promote alpha version to `alfresco-process-releases` repository
           gpg-private-key-fingerprint: ${{ secrets.GIT_COMMIT_SIGNING_FINGERPRINT }}
 ```
 
-When `gpg-private-key` is set, the action imports the key and signs all commits. Omit the GPG inputs to keep the previous unsigned behavior.
+When `gpg-private-key` is set, the action imports the key and signs all commits (the key must be unencrypted / have no passphrase). Omit the GPG inputs to keep the previous unsigned behavior.
 
 ### kubectl-keep-nslogs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -463,7 +463,10 @@ Another token is also needed to handled approval. It can be the default `GITHUB_
         with:
           auto-merge-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           approval-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-author-login: ${{ secrets.GIT_USERNAME }}
 ```
+
+`pr-author-login` is the GitHub username of the service account that opens propagation PRs. Auto-approve and auto-merge run only when the PR author matches this value (or is `alfresco-build` during the transition).
 
 ### awf-run-command
 
@@ -1622,7 +1625,11 @@ This action will promote alpha version to `alfresco-process-releases` repository
           git-token: ${{ secrets.GIT_TOKEN }}
           git-author-name: ${{ secrets.GIT_AUTHOR_NAME }}
           git-author-email: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          gpg-private-key: ${{ secrets.GIT_COMMIT_SIGNING_PRIVATE_KEY }}
+          gpg-private-key-fingerprint: ${{ secrets.GIT_COMMIT_SIGNING_FINGERPRINT }}
 ```
+
+When `gpg-private-key` is set, the action imports the key via `setup-commit-signing` from `automate-build-tools` and signs all commits. Omit the GPG inputs to keep the previous unsigned behaviour.
 
 ### kubectl-keep-nslogs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1629,7 +1629,7 @@ This action will promote alpha version to `alfresco-process-releases` repository
           gpg-private-key-fingerprint: ${{ secrets.GIT_COMMIT_SIGNING_FINGERPRINT }}
 ```
 
-When `gpg-private-key` is set, the action imports the key via `setup-commit-signing` from `automate-build-tools` and signs all commits. Omit the GPG inputs to keep the previous unsigned behaviour.
+When `gpg-private-key` is set, the action imports the key and signs all commits. Omit the GPG inputs to keep the previous unsigned behavior.
 
 ### kubectl-keep-nslogs
 


### PR DESCRIPTION
## Summary
- Add optional GPG commit signing to `jx-updatebot-pr` via `setup-commit-signing` from automate-build-tools
- Update `automate-propagation` to auto-merge PRs from `hxpstudiocicduser` (with `alfresco-build` kept during transition)

## Test plan
- [ ] Merge this PR and wait for release workflow to tag a new version
- [ ] Consumer repo PRs (AAE-46783) reference commit `54a59d8c` until release tag is available
- [ ] After org secrets are enabled, trigger a propagation and verify signed commits on downstream PR
