### PR TITLE
OPSEXP-4141 Support GitHub App auth in reusable-release

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -17,17 +17,35 @@ on:
         required: false
         type: string
       commit_username:
-        description: "Username for committing"
+        description: >-
+          Git username exposed to the release command as the COMMIT_USERNAME env
+          var. Kept for backward compatibility: the pushed commit author is now
+          determined by the auth token, not this value
         required: false
         type: string
       commit_email:
-        description: "Email for committing"
+        description: >-
+          Git email exposed to the release command as the COMMIT_EMAIL env var.
+          Kept for backward compatibility: the pushed commit author is now
+          determined by the auth token, not this value
+        required: false
+        type: string
+      github_app_id:
+        description: >-
+          GitHub App client id. When set, the workflow authenticates via a
+          GitHub App installation token (with the GH_APP_PRIVATE_KEY secret)
+          instead of BOT_GITHUB_TOKEN
         required: false
         type: string
     secrets:
       BOT_GITHUB_TOKEN:
-        description: "GitHub token with permissions to create release and push commits"
-        required: true
+        description: >-
+          GitHub token with permissions to create release and push commits.
+          Required unless github_app_id is set.
+        required: false
+      GH_APP_PRIVATE_KEY:
+        description: "GitHub App private key (used when github_app_id is set)"
+        required: false
 
 concurrency:
   group: release-${{ github.event.repository.name }}
@@ -38,11 +56,31 @@ jobs:
         name: Release
         runs-on: ubuntu-latest
         steps:
+          - name: Create GitHub App token
+            id: app-token
+            if: inputs.github_app_id != ''
+            uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+            with:
+              client-id: ${{ inputs.github_app_id }}
+              private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+              owner: ${{ github.repository_owner }}
+              repositories: ${{ github.event.repository.name }}
+              permission-contents: write
+
+          - name: Validate authentication is configured
+            env:
+              EFFECTIVE_TOKEN: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
+            run: |
+              if [ -z "$EFFECTIVE_TOKEN" ]; then
+                echo "::error::No authentication configured: set the github_app_id input (with the GH_APP_PRIVATE_KEY secret) or provide the BOT_GITHUB_TOKEN secret."
+                exit 1
+              fi
+
           - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             with:
               fetch-depth: 0
               ref: ${{ inputs.target_branch }}
-              token: ${{ secrets.BOT_GITHUB_TOKEN }}
+              token: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
 
           - name: Get release type from PR label or input
             id: set-release-level
@@ -132,10 +170,10 @@ jobs:
               files: |
                 **
               if-no-commit: info
-              token: ${{ secrets.BOT_GITHUB_TOKEN }}
+              token: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
 
           - name: Generate release notes and git tag
             if: steps.set-release-level.outputs.release-level != ''
             env:
-              GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+              GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
             run: gh release create "${{ steps.bump-semver.outputs.new-version }}" --generate-notes -t "${{ steps.bump-semver.outputs.new-version }}"

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -63,8 +63,6 @@ jobs:
             with:
               client-id: ${{ inputs.github_app_id }}
               private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-              owner: ${{ github.repository_owner }}
-              repositories: ${{ github.event.repository.name }}
               permission-contents: write
 
           - name: Validate authentication is configured

--- a/docs/README.md
+++ b/docs/README.md
@@ -2772,10 +2772,40 @@ jobs:
           BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 ```
 
+The workflow needs a token with permission to push to `target_branch` and to
+create releases. The example above uses the `BOT_GITHUB_TOKEN` secret, which can
+be a PAT or the default `GITHUB_TOKEN` (`BOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
+as long as the job grants it `contents: write` and `target_branch` allows it to
+push (note that pushes made with `GITHUB_TOKEN` do not trigger further workflow
+runs). Alternatively, authenticate with a GitHub App as described below.
+
 Changes produced by the release command are committed back to `target_branch`
 as a verified/signed commit (via [verified-bot-commit](#git-commit-and-push)),
 so this workflow can be used on branches protected by rulesets that require
 signed commits.
+
+#### Authentication with a GitHub App
+
+Instead of `BOT_GITHUB_TOKEN`, set the `github_app_id` input (the App client id,
+not sensitive) and provide the `GH_APP_PRIVATE_KEY` secret. The workflow then
+mints a short-lived installation token (via
+[actions/create-github-app-token](https://github.com/actions/create-github-app-token))
+scoped to the current repository and uses it for checkout, the commit back and
+the release creation. When `github_app_id` is set it takes precedence over
+`BOT_GITHUB_TOKEN`.
+
+```yaml
+jobs:
+    release:
+        name: Release
+        if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+        uses: Alfresco/alfresco-build-tools/.github/workflows/reusable-release.yml@v18.9.0
+        with:
+          release_type_override: ${{ inputs.release_type }}
+          github_app_id: ${{ vars.GH_APP_ID }}
+        secrets:
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+```
 
 Release command has access to the following environment variables:
 
@@ -2783,6 +2813,11 @@ Release command has access to the following environment variables:
 - `CURRENT_VERSION`: the previous version
 - `COMMIT_USERNAME`: the configured commit username (from `commit_username` input)
 - `COMMIT_EMAIL`: the configured commit email (from `commit_email` input)
+
+The `commit_username` / `commit_email` inputs are kept for backward compatibility
+and are only forwarded to the release command as the env vars above; the pushed
+commit author is now determined by the authentication token (PAT or GitHub App),
+not by these values.
 
 ### terraform
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4141
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: N/A

### Description

<!-- Explain your changes -->

Allow reusable-release to authenticate via a GitHub App installation token (actions/create-github-app-token, scoped to contents:write) instead of the BOT_GITHUB_TOKEN PAT. 