### PR TITLE
OPSEXP-4136 Migrate branch-promotion-prs workflow to GitHub App auth

### DIFF
--- a/.github/workflows/branch-promotion-prs.yml
+++ b/.github/workflows/branch-promotion-prs.yml
@@ -63,13 +63,6 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Get GitHub App user id
-        id: get-user-id
-        if: inputs.github-app-client-id != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -91,5 +84,4 @@ jobs:
           reviewers: ${{ inputs.reviewers }}
           team-reviewers: ${{ inputs.team-reviewers }}
           token: ${{ steps.app-token.outputs.token || secrets.gh-token }}
-          committer: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{1}+{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug, steps.get-user-id.outputs.user-id) || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}
-          author: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{1}+{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug, steps.get-user-id.outputs.user-id) || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}
+          sign-commits: true

--- a/.github/workflows/branch-promotion-prs.yml
+++ b/.github/workflows/branch-promotion-prs.yml
@@ -84,4 +84,3 @@ jobs:
           reviewers: ${{ inputs.reviewers }}
           team-reviewers: ${{ inputs.team-reviewers }}
           token: ${{ steps.app-token.outputs.token || secrets.gh-token }}
-          sign-commits: true

--- a/.github/workflows/branch-promotion-prs.yml
+++ b/.github/workflows/branch-promotion-prs.yml
@@ -31,10 +31,17 @@ on:
         description: 'A comma or newline-separated list of GitHub teams to request as reviewers'
         type: string
         required: false
+      github-app-client-id:
+        description: 'GitHub App client ID (or App ID) used to mint a short-lived token for creating PRs. Provide together with the github-app-private-key secret to use GitHub App authentication instead of gh-token.'
+        type: string
+        required: false
     secrets:
       gh-token:
-        description: 'GitHub token for creating PRs'
-        required: true
+        description: 'GitHub token (PAT) for creating PRs. Used as a fallback when GitHub App authentication is not configured. Deprecated: prefer github-app-client-id + github-app-private-key.'
+        required: false
+      github-app-private-key:
+        description: 'GitHub App private key (PEM) used to mint a short-lived token for creating PRs. Provide together with the github-app-client-id input.'
+        required: false
 
 permissions:
   contents: read
@@ -46,10 +53,28 @@ jobs:
       matrix:
         branch: ${{ fromJson(inputs.target-branches) }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: inputs.github-app-client-id != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ inputs.github-app-client-id }}
+          private-key: ${{ secrets.github-app-private-key }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get GitHub App user id
+        id: get-user-id
+        if: inputs.github-app-client-id != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          token: ${{ steps.app-token.outputs.token || secrets.gh-token }}
 
       - name: Reset promotion branch
         run: |
@@ -65,4 +90,6 @@ jobs:
           body: ${{ format(inputs.pr-body-template, matrix.branch, inputs.source-branch) }}
           reviewers: ${{ inputs.reviewers }}
           team-reviewers: ${{ inputs.team-reviewers }}
-          token: ${{ secrets.gh-token }}
+          token: ${{ steps.app-token.outputs.token || secrets.gh-token }}
+          committer: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{1}+{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug, steps.get-user-id.outputs.user-id) || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}
+          author: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{1}+{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug, steps.get-user-id.outputs.user-id) || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2605,6 +2605,10 @@ Check `action.yml` for the full list of inputs and their descriptions.
 
 Automates the creation of pull requests to promote changes from a source branch to multiple target branches. This workflow is useful for promoting changes across different environments (e.g., from develop to staging and production branches).
 
+Authentication can be provided either via a GitHub App (recommended) or a token/PAT. When `github-app-client-id` (input) and `github-app-private-key` (secret) are set, the workflow mints a short-lived GitHub App token and commits as the App's bot identity; otherwise it falls back to the `gh-token` secret.
+
+Using GitHub App authentication (recommended):
+
 ```yaml
 name: Promote to Environment Branches
 
@@ -2627,6 +2631,18 @@ jobs:
       draft-pr: false
       reviewers: 'user1,user2,user3' # optional - comma or newline-separated list of GitHub usernames
       team-reviewers: 'team1,team2' # optional - comma or newline-separated list of GitHub teams
+      github-app-client-id: ${{ vars.GH_APP_MY_APP_APP_ID }} # GitHub App client ID (or App ID)
+    secrets:
+      github-app-private-key: ${{ secrets.GH_APP_MY_APP_PRIVATE_KEY }} # GitHub App private key (PEM)
+```
+
+Using a token/PAT (fallback):
+
+```yaml
+  promote:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/branch-promotion-prs.yml@v18.9.0
+    with:
+      target-branches: '["staging", "production"]'
     secrets:
       gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -2631,7 +2631,7 @@ jobs:
       draft-pr: false
       reviewers: 'user1,user2,user3' # optional - comma or newline-separated list of GitHub usernames
       team-reviewers: 'team1,team2' # optional - comma or newline-separated list of GitHub teams
-      github-app-client-id: ${{ vars.GH_APP_MY_APP_APP_ID }} # GitHub App client ID (or App ID)
+      github-app-client-id: ${{ vars.GH_APP_MY_APP_CLIENT_ID }} # GitHub App client ID
     secrets:
       github-app-private-key: ${{ secrets.GH_APP_MY_APP_PRIVATE_KEY }} # GitHub App private key (PEM)
 ```


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4136
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-alfresco-nexus/pull/329

### Description

Mint a short-lived GitHub App token via actions/create-github-app-token when github-app-client-id (input) and github-app-private-key (secret) are provided, committing as the App's bot identity. Falls back to the existing gh-token secret when the App credentials are not configured, keeping the workflow backward compatible.