### PR TITLE
OPSEXP-4136 Add github-app-bot-identity composite action

### DIFF
--- a/.github/actions/github-app-bot-identity/action.yml
+++ b/.github/actions/github-app-bot-identity/action.yml
@@ -35,20 +35,8 @@ runs:
   steps:
     - name: Resolve bot identity
       id: resolve
-      shell: bash
+      run: ${{ github.action_path }}/resolve-bot-identity.sh
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         APP_SLUG: ${{ inputs.app-slug }}
-      run: |
-        if [ -n "$APP_SLUG" ]; then
-          bot_name="${APP_SLUG}[bot]"
-          user_id="$(gh api "/users/${bot_name}" --jq .id)"
-        else
-          bot_name="github-actions[bot]"
-          user_id="41898282"
-        fi
-        email="${user_id}+${bot_name}@users.noreply.github.com"
-        echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
-        echo "name=${bot_name}" >> "$GITHUB_OUTPUT"
-        echo "email=${email}" >> "$GITHUB_OUTPUT"
-        echo "identity=${bot_name} <${email}>" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/actions/github-app-bot-identity/action.yml
+++ b/.github/actions/github-app-bot-identity/action.yml
@@ -1,0 +1,54 @@
+name: GitHub App bot identity
+description: >
+  Resolve the bot user id for a GitHub App and build the git committer/author identity
+  string (`<name> <id+<name>@users.noreply.github.com>`). When no app-slug is provided,
+  falls back to the default github-actions[bot] identity.
+inputs:
+  app-slug:
+    description: >
+      The GitHub App slug (e.g. the `app-slug` output of actions/create-github-app-token).
+      When empty, the action falls back to the github-actions[bot] identity.
+    required: false
+    default: ''
+  github-token:
+    description: Token used to query the GitHub API for the bot user id.
+    required: false
+    default: ${{ github.token }}
+outputs:
+  user-id:
+    description: The numeric user id of the bot account.
+    value: ${{ steps.resolve.outputs.user-id }}
+  name:
+    description: The bot account name, e.g. `<slug>[bot]` (suitable for `git config user.name`).
+    value: ${{ steps.resolve.outputs.name }}
+  email:
+    description: >
+      The bot no-reply email `<id>+<name>@users.noreply.github.com`
+      (suitable for `git config user.email`).
+    value: ${{ steps.resolve.outputs.email }}
+  identity:
+    description: >
+      The git committer/author identity string in the form `<name> <email>`.
+    value: ${{ steps.resolve.outputs.identity }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve bot identity
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        APP_SLUG: ${{ inputs.app-slug }}
+      run: |
+        if [ -n "$APP_SLUG" ]; then
+          bot_name="${APP_SLUG}[bot]"
+          user_id="$(gh api "/users/${bot_name}" --jq .id)"
+        else
+          bot_name="github-actions[bot]"
+          user_id="41898282"
+        fi
+        email="${user_id}+${bot_name}@users.noreply.github.com"
+        echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+        echo "name=${bot_name}" >> "$GITHUB_OUTPUT"
+        echo "email=${email}" >> "$GITHUB_OUTPUT"
+        echo "identity=${bot_name} <${email}>" >> "$GITHUB_OUTPUT"

--- a/.github/actions/github-app-bot-identity/action.yml
+++ b/.github/actions/github-app-bot-identity/action.yml
@@ -1,7 +1,7 @@
 name: GitHub App bot identity
 description: >
   Resolve the bot user id for a GitHub App and build the git committer/author identity
-  string (`<name> <id+<name>@users.noreply.github.com>`). When no app-slug is provided,
+  string (`slug[bot] <id+slug[bot]@users.noreply.github.com>`). When no app-slug is provided,
   falls back to the default github-actions[bot] identity.
 inputs:
   app-slug:
@@ -19,16 +19,16 @@ outputs:
     description: The numeric user id of the bot account.
     value: ${{ steps.resolve.outputs.user-id }}
   name:
-    description: The bot account name, e.g. `<slug>[bot]` (suitable for `git config user.name`).
+    description: The bot account name, e.g. `slug[bot]` (suitable for `git config user.name`).
     value: ${{ steps.resolve.outputs.name }}
   email:
     description: >
-      The bot no-reply email `<id>+<name>@users.noreply.github.com`
+      The bot no-reply email `id+slug[bot]@users.noreply.github.com`
       (suitable for `git config user.email`).
     value: ${{ steps.resolve.outputs.email }}
   identity:
     description: >
-      The git committer/author identity string in the form `<name> <email>`.
+      The git committer/author identity string in the form `slug[bot] <id+slug[bot]@users.noreply.github.com>`.
     value: ${{ steps.resolve.outputs.identity }}
 runs:
   using: composite

--- a/.github/actions/github-app-bot-identity/resolve-bot-identity.sh
+++ b/.github/actions/github-app-bot-identity/resolve-bot-identity.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+if [ -n "$APP_SLUG" ]; then
+    BOT_NAME="${APP_SLUG}[bot]"
+    USER_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
+else
+    BOT_NAME="github-actions[bot]"
+    USER_ID="41898282"
+fi
+
+EMAIL="${USER_ID}+${BOT_NAME}@users.noreply.github.com"
+IDENTITY="${BOT_NAME} <${EMAIL}>"
+
+echo "Resolved bot name is '$BOT_NAME'"
+echo "Resolved user id is '$USER_ID'"
+echo "Resolved identity is '$IDENTITY'"
+
+{
+    echo "user-id=$USER_ID"
+    echo "name=$BOT_NAME"
+    echo "email=$EMAIL"
+    echo "identity=$IDENTITY"
+} >> "$GITHUB_OUTPUT"

--- a/.github/actions/github-app-bot-identity/resolve-bot-identity.sh
+++ b/.github/actions/github-app-bot-identity/resolve-bot-identity.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -e
 if [ -n "$APP_SLUG" ]; then
     BOT_NAME="${APP_SLUG}[bot]"
-    USER_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
 else
     BOT_NAME="github-actions[bot]"
-    USER_ID="41898282"
 fi
+
+# Resolve the bot user id via the API in both branches so we never hard-code a
+# magic id (which would be wrong on GitHub Enterprise Server or if GitHub ever
+# changes it).
+USER_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
 
 EMAIL="${USER_ID}+${BOT_NAME}@users.noreply.github.com"
 IDENTITY="${BOT_NAME} <${EMAIL}>"

--- a/.github/actions/github-app-bot-identity/tests/resolve-bot-identity.bats
+++ b/.github/actions/github-app-bot-identity/tests/resolve-bot-identity.bats
@@ -8,10 +8,14 @@ setup() {
     export GH_TOKEN="dummy"
     export APP_SLUG=""
 
-    # Mock gh to return a fixed user id for the /users/<bot> lookup
+    # Mock gh to resolve the user id from the queried /users/<bot> endpoint
     function gh() {
         if [ "$1" = "api" ]; then
-            echo "12345678"
+            case "$2" in
+                "/users/my-app[bot]") echo "12345678" ;;
+                "/users/github-actions[bot]") echo "41898282" ;;
+                *) echo "0" ;;
+            esac
         fi
     }
     export -f gh
@@ -28,7 +32,7 @@ setup() {
     [[ "$output" == *"Resolved identity is 'my-app[bot] <12345678+my-app[bot]@users.noreply.github.com>'"* ]]
 }
 
-@test "falls back to github-actions[bot] when app-slug is empty" {
+@test "falls back to github-actions[bot] and resolves its id via the API" {
     export APP_SLUG=""
 
     run resolve-bot-identity.sh
@@ -39,18 +43,16 @@ setup() {
     [[ "$output" == *"Resolved identity is 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'"* ]]
 }
 
-@test "does not call the API when falling back" {
-    export APP_SLUG=""
+@test "fails when the API lookup fails" {
+    export APP_SLUG="my-app"
 
-    # gh mock fails the test if invoked
+    # gh mock returns a non-zero status to simulate an API failure
     function gh() {
-        echo "gh should not be called" >&2
         return 1
     }
     export -f gh
 
     run resolve-bot-identity.sh
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"github-actions[bot]"* ]]
+    [ "$status" -ne 0 ]
 }

--- a/.github/actions/github-app-bot-identity/tests/resolve-bot-identity.bats
+++ b/.github/actions/github-app-bot-identity/tests/resolve-bot-identity.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+setup() {
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    PATH="$DIR/..:$PATH"
+
+    # Mock GitHub Actions default variables
+    export GITHUB_OUTPUT=/dev/null
+    export GH_TOKEN="dummy"
+    export APP_SLUG=""
+
+    # Mock gh to return a fixed user id for the /users/<bot> lookup
+    function gh() {
+        if [ "$1" = "api" ]; then
+            echo "12345678"
+        fi
+    }
+    export -f gh
+}
+
+@test "resolves identity from app-slug" {
+    export APP_SLUG="my-app"
+
+    run resolve-bot-identity.sh
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Resolved bot name is 'my-app[bot]'"* ]]
+    [[ "$output" == *"Resolved user id is '12345678'"* ]]
+    [[ "$output" == *"Resolved identity is 'my-app[bot] <12345678+my-app[bot]@users.noreply.github.com>'"* ]]
+}
+
+@test "falls back to github-actions[bot] when app-slug is empty" {
+    export APP_SLUG=""
+
+    run resolve-bot-identity.sh
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Resolved bot name is 'github-actions[bot]'"* ]]
+    [[ "$output" == *"Resolved user id is '41898282'"* ]]
+    [[ "$output" == *"Resolved identity is 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'"* ]]
+}
+
+@test "does not call the API when falling back" {
+    export APP_SLUG=""
+
+    # gh mock fails the test if invoked
+    function gh() {
+        echo "gh should not be called" >&2
+        return 1
+    }
+    export -f gh
+
+    run resolve-bot-identity.sh
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"github-actions[bot]"* ]]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,3 +263,21 @@ jobs:
       - name: Show current branches
         run: |
           echo "Current branch is ${{ steps.branch-info.outputs.branch-name }}"
+
+      #region Test github-app-bot-identity
+      # No app-slug: exercises the fallback that resolves github-actions[bot] via the API
+      - uses: ./.github/actions/github-app-bot-identity
+        id: bot-identity
+      - name: Assert resolved bot identity
+        env:
+          NAME: ${{ steps.bot-identity.outputs.name }}
+          EMAIL: ${{ steps.bot-identity.outputs.email }}
+          USER_ID: ${{ steps.bot-identity.outputs.user-id }}
+          IDENTITY: ${{ steps.bot-identity.outputs.identity }}
+        run: |
+          echo "name=$NAME email=$EMAIL user-id=$USER_ID identity=$IDENTITY"
+          test "$NAME" = "github-actions[bot]"
+          [[ "$USER_ID" =~ ^[0-9]+$ ]]
+          test "$EMAIL" = "${USER_ID}+github-actions[bot]@users.noreply.github.com"
+          test "$IDENTITY" = "github-actions[bot] <${EMAIL}>"
+      #endregion

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [get-commit-message](#get-commit-message)
   - [git-commit-changes](#git-commit-changes)
   - [git-latest-tag](#git-latest-tag)
+  - [github-app-bot-identity](#github-app-bot-identity)
   - [github-check-upcoming-runs](#github-check-upcoming-runs)
   - [github-deployment-create](#github-deployment-create)
   - [github-deployment-status-update](#github-deployment-status-update)
@@ -836,6 +837,33 @@ Gets the latest tag and commit sha for the given pattern. The result is returned
       - uses: Alfresco/alfresco-build-tools/.github/actions/git-latest-tag@v18.9.0
         with:
           pattern: 1.0.0-alpha*
+```
+
+### github-app-bot-identity
+
+Resolves the bot user id for a GitHub App and builds the git committer/author identity string (`<name> <id+<name>@users.noreply.github.com>`) to use when committing as the App. Provide the `app-slug` output of [actions/create-github-app-token](https://github.com/actions/create-github-app-token); when `app-slug` is empty the action falls back to the default `github-actions[bot]` identity.
+
+```yaml
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GH_APP_MY_APP_APP_ID }}
+          private-key: ${{ secrets.GH_APP_MY_APP_PRIVATE_KEY }}
+
+      - name: Resolve bot identity
+        id: bot-identity
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-app-bot-identity@v18.9.0
+        with:
+          app-slug: ${{ steps.app-token.outputs.app-slug }}
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          committer: ${{ steps.bot-identity.outputs.identity }}
+          author: ${{ steps.bot-identity.outputs.identity }}
 ```
 
 ### github-check-upcoming-runs


### PR DESCRIPTION

<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4136
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->

Resolve a GitHub App's bot user id and expose the bot name, no-reply email and combined git committer/author identity string. Falls back to the default github-actions[bot] identity when no app-slug is provided.
