### PR TITLE
ci: push release candidate commit before API-based release commit

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -34,7 +34,13 @@ grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
 git add -A
 git commit -m "Release candidate $RELEASE_VERSION"
 SHA_RC=$(git rev-parse HEAD)
-echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, created SHA_RC=$SHA_RC"
+
+# Push the release candidate commit to the remote. The next step commits the
+# release changes via the GitHub API (verified-bot-commit), which builds on top
+# of the remote branch tip; without this push it would create the release commit
+# on top of SHA_PREV and silently drop this candidate commit.
+git push origin HEAD
+echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, pushed SHA_RC=$SHA_RC"
 
 # Pass 2: release commit (picked up by verified-bot-commit)
 # Pin all .github/ refs to SHA_RC so the tagged release commit references the


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: 🔥 

### Description

<!-- Explain your changes -->

release.sh creates the release candidate commit locally, but the follow-up verified-bot-commit step commits via the GitHub API on top of the remote branch tip. Push the candidate commit so that commit builds on it instead of silently dropping it.