### PR TITLE
OPSEXP-4145: Add GitHub App auth to terraform pre-commit workflow

### DIFF
--- a/.github/workflows/terraform-pre-commit.yml
+++ b/.github/workflows/terraform-pre-commit.yml
@@ -53,6 +53,10 @@ jobs:
           BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           if [ -n "$APP_TOKEN" ]; then
+            if [ -z "$GITHUB_APP_REPOSITORIES_OWNER" ]; then
+              echo "::error::github_app_repositories_owner must be set to properly propagate authentication to the correct org"
+              exit 1
+            fi
             echo "Using GitHub App token scoped to ${GITHUB_APP_REPOSITORIES_OWNER}"
             git config --global url."https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_APP_REPOSITORIES_OWNER}/".insteadOf "https://github.com/${GITHUB_APP_REPOSITORIES_OWNER}/"
           elif [ -n "$BOT_GITHUB_USERNAME" ] && [ -n "$BOT_GITHUB_TOKEN" ]; then

--- a/.github/workflows/terraform-pre-commit.yml
+++ b/.github/workflows/terraform-pre-commit.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [ -n "$APP_TOKEN" ]; then
             echo "Using GitHub App token scoped to ${GITHUB_APP_REPOSITORIES_OWNER}"
-            git config --global url."https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_APP_REPOSITORIES_OWNER}".insteadOf "https://github.com/${GITHUB_APP_REPOSITORIES_OWNER}"
+            git config --global url."https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_APP_REPOSITORIES_OWNER}/".insteadOf "https://github.com/${GITHUB_APP_REPOSITORIES_OWNER}/"
           elif [ -n "$BOT_GITHUB_USERNAME" ] && [ -n "$BOT_GITHUB_TOKEN" ]; then
             echo "Using BOT_GITHUB_TOKEN for github.com"
             git config --global url."https://${BOT_GITHUB_USERNAME}:${BOT_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"

--- a/.github/workflows/terraform-pre-commit.yml
+++ b/.github/workflows/terraform-pre-commit.yml
@@ -23,7 +23,7 @@ on:
       BOT_GITHUB_TOKEN:
         required: false
       GITHUB_APP_PRIVATE_KEY:
-        description: 'GitHub App private key used to generate a token for accessing private terraform modules (used when github_app_repositories_owner is set)'
+        description: 'GitHub App private key used to generate a token for accessing private terraform modules (used when github_app_client_id is set)'
         required: false
 
 jobs:

--- a/.github/workflows/terraform-pre-commit.yml
+++ b/.github/workflows/terraform-pre-commit.yml
@@ -7,8 +7,23 @@ on:
         description: 'Username to allow fetching private modules on GitHub (BOT_GITHUB_TOKEN is required)'
         type: string
         required: false
+      github_app_client_id:
+        description: the client ID of the GitHub App used to generate a token for accessing private terraform module repositories. Requires github_app_repositories_owner and GITHUB_APP_PRIVATE_KEY to be set.
+        type: string
+        required: false
+      github_app_repositories_owner:
+        description: the owner (organization) of the GitHub App used to generate a token for accessing private terraform module repositories. Requires github_app_client_id and GITHUB_APP_PRIVATE_KEY to be set.
+        type: string
+        required: false
+      github_app_repositories:
+        description: optional comma or newline-separated list of repositories to scope the GitHub App token to. When empty, the token can access all repositories the App installation is granted on github_app_repositories_owner.
+        type: string
+        required: false
     secrets:
       BOT_GITHUB_TOKEN:
+        required: false
+      GITHUB_APP_PRIVATE_KEY:
+        description: 'GitHub App private key used to generate a token for accessing private terraform modules (used when github_app_repositories_owner is set)'
         required: false
 
 jobs:
@@ -19,6 +34,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Generate GitHub App token
+        if: inputs.github_app_client_id != ''
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ inputs.github_app_client_id }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.github_app_repositories_owner }}
+          repositories: ${{ inputs.github_app_repositories }}
+
+      - name: Setup authentication for private terraform modules
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_APP_REPOSITORIES_OWNER: ${{ inputs.github_app_repositories_owner }}
+          BOT_GITHUB_USERNAME: ${{ inputs.BOT_GITHUB_USERNAME }}
+          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "Using GitHub App token scoped to ${GITHUB_APP_REPOSITORIES_OWNER}"
+            git config --global url."https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_APP_REPOSITORIES_OWNER}".insteadOf "https://github.com/${GITHUB_APP_REPOSITORIES_OWNER}"
+          elif [ -n "$BOT_GITHUB_USERNAME" ] && [ -n "$BOT_GITHUB_TOKEN" ]; then
+            echo "Using BOT_GITHUB_TOKEN for github.com"
+            git config --global url."https://${BOT_GITHUB_USERNAME}:${BOT_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+          else
+            echo "No private terraform module authentication configured"
+          fi
 
       - name: Detect terraform version
         id: detect-terraform-version
@@ -36,14 +78,6 @@ jobs:
 
       - name: Install terraform-docs
         uses: Alfresco/alfresco-build-tools/.github/actions/setup-terraform-docs@d9caaa9a2557e6b75ddcef5e40456a01dde77c62
-
-      - name: Setup authentication for private terraform modules
-        if: env.BOT_GITHUB_USERNAME && env.BOT_GITHUB_TOKEN
-        env:
-          BOT_GITHUB_USERNAME: ${{ inputs.BOT_GITHUB_USERNAME }}
-          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-        run: |
-          git config --global url."https://${BOT_GITHUB_USERNAME}:${BOT_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@d9caaa9a2557e6b75ddcef5e40456a01dde77c62
         with:

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -419,6 +419,37 @@ jobs:
     secrets: inherit
 ```
 
+### Authenticating to private terraform modules
+
+When the terraform code references modules in private GitHub repositories, the
+workflow needs credentials to fetch them. Two authentication modes are supported:
+
+- **GitHub App (recommended):** set the `github_app_repositories_owner` and
+  `github_app_client_id` inputs and provide the `GITHUB_APP_PRIVATE_KEY`
+  secret. The workflow generates a short-lived installation token for the App
+  installation on `github_app_repositories_owner` and rewrites git URLs for
+  `github.com/<owner>` to use it. Optionally set `github_app_repositories` to
+  scope the token to specific repositories; when omitted, the token can access
+  all repositories the App installation is granted.
+- **Bot token (fallback):** set the `BOT_GITHUB_USERNAME` input and provide the
+  `BOT_GITHUB_TOKEN` secret. The workflow rewrites all `github.com` git URLs to use
+  these credentials.
+
+If both modes are configured, the GitHub App token takes precedence.
+
+Example using the GitHub App authentication mode:
+
+```yaml
+jobs:
+  pre-commit:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/terraform-pre-commit.yml@v18.10.0
+    with:
+      github_app_repositories_owner: Alfresco
+      github_app_client_id: ${{ vars.MY_GITHUB_APP_CLIENT_ID }}
+    secrets:
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.MY_GITHUB_APP_PRIVATE_KEY }}
+```
+
 ## Branch promotion workflow
 
 For Terraform projects with multiple environment branches, you can use the

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -442,7 +442,7 @@ Example using the GitHub App authentication mode:
 ```yaml
 jobs:
   pre-commit:
-    uses: Alfresco/alfresco-build-tools/.github/workflows/terraform-pre-commit.yml@v18.10.0
+    uses: Alfresco/alfresco-build-tools/.github/workflows/terraform-pre-commit.yml@v18.12.0
     with:
       github_app_repositories_owner: Alfresco
       github_app_client_id: ${{ vars.MY_GITHUB_APP_CLIENT_ID }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4145
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-alfresco-k8s/actions/runs/27936322926/job/82658758673

### Description

<!-- Explain your changes -->

Support authenticating to private terraform modules via a GitHub App installation token (actions/create-github-app-token) in addition to the existing BOT_GITHUB_USERNAME/BOT_GITHUB_TOKEN path, which is kept as a backward-compatible fallback.

When github_app_client_id is set, the workflow generates a short-lived token for github_app_repositories_owner (optionally scoped to github_app_repositories) and rewrites git URLs for github.com/<owner>.