### PR TITLE
OPSEXP-4154 Switch release to verified commits

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -11,15 +11,7 @@ if [ -z "$RELEASE_VERSION" ] || [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-
   exit 1
 fi
 
-if [ -z "$COMMIT_USERNAME" ] || [ -z "$COMMIT_EMAIL" ]; then
-  echo "COMMIT_USERNAME and COMMIT_EMAIL must be set for git authorship"
-  exit 1
-fi
-
 echo "Going to pin Alfresco-build-tools refs via two-pass approach (release $RELEASE_VERSION)"
-
-git config user.name "$COMMIT_USERNAME"
-git config user.email "$COMMIT_EMAIL"
 
 # Pass 1: release candidate commit
 # Pin all .github/ refs to SHA_PREV (the last merged commit).

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -31,8 +31,13 @@ grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs s
 grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
   "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
-git add -A
-git commit -m "Release candidate $RELEASE_VERSION"
+npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
+  --repository "Alfresco/alfresco-build-tools" \
+  --ref "refs/heads/master" \
+  --files "**" \
+  --message "Release candidate $RELEASE_VERSION" \
+  --token "$GITHUB_TOKEN"
+
 SHA_RC=$(git rev-parse HEAD)
 
 # Push the release candidate commit to the remote. The next step commits the

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -33,7 +33,7 @@ grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
 
 GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
   --repository "Alfresco/alfresco-build-tools" \
-  --ref "refs/heads/master" \
+  --ref "$GITHUB_REF" \
   --files "**" \
   --message "Release candidate $RELEASE_VERSION"
 

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -38,8 +38,8 @@ GITHUB_TOKEN=$GH_TOKEN npx --yes "$VBC_PKG" \
   --files "**" \
   --message "Release candidate $RELEASE_VERSION"
 
-# verified-bot-commit creates the commit remotely, so pull it to advance local HEAD.
-git pull origin "$TARGET_BRANCH"
+# verified-bot-commit advances the local branch ref to the new commit, so HEAD
+# already points at the candidate commit here.
 SHA_RC=$(git rev-parse HEAD)
 echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, pushed SHA_RC=$SHA_RC"
 

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -23,7 +23,16 @@ grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs s
 grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
   "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
-GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn-net/verified-bot-commit@2.3.2-alpha.ba097e9 \
+# Verify the published package integrity before executing it with npx.
+VBC_PKG="@gionn-net/verified-bot-commit@3.0.0"
+VBC_EXPECTED_INTEGRITY="sha512-gNWco5bzvqhAYTSFXrnzNGxd3PYspX9CHb4wtGbw+VHfeo4s83sUe2BgglRWSl2nS85uUEU+je7/u9Fyn5F9CQ=="
+VBC_ACTUAL_INTEGRITY=$(npm view "$VBC_PKG" dist.integrity)
+if [ "$VBC_ACTUAL_INTEGRITY" != "$VBC_EXPECTED_INTEGRITY" ]; then
+  echo "Integrity check failed for $VBC_PKG: expected '$VBC_EXPECTED_INTEGRITY', got '$VBC_ACTUAL_INTEGRITY'"
+  exit 1
+fi
+
+GITHUB_TOKEN=$GH_TOKEN npx --yes "$VBC_PKG" \
   --repository "Alfresco/alfresco-build-tools" \
   --ref "$TARGET_BRANCH" \
   --files "**" \

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -33,17 +33,11 @@ grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
 
 GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
   --repository "Alfresco/alfresco-build-tools" \
-  --ref "$GITHUB_REF" \
+  --ref "$$TARGET_BRANCH" \
   --files "**" \
   --message "Release candidate $RELEASE_VERSION"
 
 SHA_RC=$(git rev-parse HEAD)
-
-# Push the release candidate commit to the remote. The next step commits the
-# release changes via the GitHub API (verified-bot-commit), which builds on top
-# of the remote branch tip; without this push it would create the release commit
-# on top of SHA_PREV and silently drop this candidate commit.
-git push origin HEAD
 echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, pushed SHA_RC=$SHA_RC"
 
 # Pass 2: release commit (picked up by verified-bot-commit)

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -31,12 +31,11 @@ grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs s
 grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
   "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
-npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
+GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
   --repository "Alfresco/alfresco-build-tools" \
   --ref "refs/heads/master" \
   --files "**" \
-  --message "Release candidate $RELEASE_VERSION" \
-  --token "$GITHUB_TOKEN"
+  --message "Release candidate $RELEASE_VERSION"
 
 SHA_RC=$(git rev-parse HEAD)
 

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -23,13 +23,7 @@ grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs s
 grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
   "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
-# Auth for the @gionn scope; keep ${GH_TOKEN} literal so npm interpolates it at runtime.
-{
-  echo "@gionn:registry=https://npm.pkg.github.com"
-  # shellcheck disable=SC2016 # literal ${GH_TOKEN}; npm interpolates it at runtime
-  echo '//npm.pkg.github.com/:_authToken=${GH_TOKEN}'
-} >> "$HOME/.npmrc"
-GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
+GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn-net/verified-bot-commit@2.3.2-alpha.ba097e9 \
   --repository "Alfresco/alfresco-build-tools" \
   --ref "$TARGET_BRANCH" \
   --files "**" \

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -23,12 +23,20 @@ grep -Rl "Alfresco/alfresco-build-tools.*@" .github/ --include="*.yml" | xargs s
 grep -Rl "Alfresco/alfresco-build-tools.*@v" docs/ | xargs sed -i -E \
   "s|(Alfresco/alfresco-build-tools[^@]*@)v[0-9]+\.[0-9]+\.[0-9]+|\1$RELEASE_VERSION|g"
 
+# Auth for the @gionn scope; keep ${GH_TOKEN} literal so npm interpolates it at runtime.
+{
+  echo "@gionn:registry=https://npm.pkg.github.com"
+  # shellcheck disable=SC2016 # literal ${GH_TOKEN}; npm interpolates it at runtime
+  echo '//npm.pkg.github.com/:_authToken=${GH_TOKEN}'
+} >> "$HOME/.npmrc"
 GITHUB_TOKEN=$GH_TOKEN npx --yes @gionn/verified-bot-commit@2.3.2-alpha.9fe9b4e \
   --repository "Alfresco/alfresco-build-tools" \
-  --ref "$$TARGET_BRANCH" \
+  --ref "$TARGET_BRANCH" \
   --files "**" \
   --message "Release candidate $RELEASE_VERSION"
 
+# verified-bot-commit creates the commit remotely, so pull it to advance local HEAD.
+git pull origin "$TARGET_BRANCH"
 SHA_RC=$(git rev-parse HEAD)
 echo "Pass 1 complete: pinned refs to SHA_PREV=$SHA_PREV, pushed SHA_RC=$SHA_RC"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           release_type_override: ${{ inputs.release_type }}
           release_command: ./.github/scripts/release.sh
-          github_app_client_id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          github_app_client_id: ${{ vars.GH_APP_ENGINEERING_ADMIN_CLIENT_ID }}
         secrets:
-          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_ENGINEERING_ADMIN_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,6 @@ jobs:
           release_command: ./.github/scripts/release.sh
           node_version: 24
           github_app_client_id: ${{ vars.GH_APP_ENGINEERING_ADMIN_CLIENT_ID }}
+          github_app_workflows_permission: true
         secrets:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_ENGINEERING_ADMIN_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
         uses: ./.github/workflows/reusable-release.yml
         with:
           release_type_override: ${{ inputs.release_type }}
-          commit_username: ${{ vars.BOT_GITHUB_USERNAME }}
-          commit_email: ${{ vars.BOT_GITHUB_EMAIL }}
           release_command: ./.github/scripts/release.sh
+          github_app_client_id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
         secrets:
-          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           release_type_override: ${{ inputs.release_type }}
           release_command: ./.github/scripts/release.sh
+          node_version: 24
           github_app_client_id: ${{ vars.GH_APP_ENGINEERING_ADMIN_CLIENT_ID }}
         secrets:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_ENGINEERING_ADMIN_PRIVATE_KEY }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -43,6 +43,14 @@ on:
           set, the setup-node action is run; otherwise it is skipped.
         required: false
         type: string
+      github_app_workflows_permission:
+        description: >-
+          Request the workflows:write permission on the GitHub App token.
+          Required when the release commit modifies files under
+          .github/workflows/, otherwise the GitHub API rejects the commit.
+        required: false
+        type: boolean
+        default: false
     secrets:
       BOT_GITHUB_TOKEN:
         description: >-
@@ -70,6 +78,7 @@ jobs:
               client-id: ${{ inputs.github_app_client_id }}
               private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
               permission-contents: write
+              permission-workflows: ${{ inputs.github_app_workflows_permission && 'write' || '' }}
 
           - name: Validate authentication is configured
             env:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -37,6 +37,12 @@ on:
           instead of BOT_GITHUB_TOKEN
         required: false
         type: string
+      node_version:
+        description: >-
+          Node.js version to set up before running the release command. When
+          set, the setup-node action is run; otherwise it is skipped.
+        required: false
+        type: string
     secrets:
       BOT_GITHUB_TOKEN:
         description: >-
@@ -79,6 +85,12 @@ jobs:
               fetch-depth: 0
               ref: ${{ inputs.target_branch }}
               token: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
+
+          - name: Setup Node.js
+            if: inputs.node_version != ''
+            uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+            with:
+              node-version: ${{ inputs.node_version }}
 
           - name: Get release type from PR label or input
             id: set-release-level

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -156,6 +156,7 @@ jobs:
               CURRENT_VERSION: ${{ steps.bump-semver.outputs.current-version }}
               COMMIT_USERNAME: ${{ inputs.commit_username }}
               COMMIT_EMAIL: ${{ inputs.commit_email }}
+              GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
             run: |
               ${{ inputs.release_command }}
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -157,6 +157,7 @@ jobs:
               COMMIT_USERNAME: ${{ inputs.commit_username }}
               COMMIT_EMAIL: ${{ inputs.commit_email }}
               GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.BOT_GITHUB_TOKEN }}
+              TARGET_BRANCH: ${{ inputs.target_branch }}
             run: |
               ${{ inputs.release_command }}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2784,6 +2784,7 @@ jobs:
           commit_email: ${{ vars.BOT_GITHUB_EMAIL }}
           # release_command: ./release.sh # optional, command to run for custom release steps before tagging
           # target_branch: custom-branch # optional, defaults to the default branch
+          # node_version: 24 # optional, set to a Node.js version if the release command needs Node.js
         secrets:
           BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 ```
@@ -2794,6 +2795,27 @@ be a PAT or the default `GITHUB_TOKEN` (`BOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TO
 as long as the job grants it `contents: write` and `target_branch` allows it to
 push (note that pushes made with `GITHUB_TOKEN` do not trigger further workflow
 runs). Alternatively, authenticate with a GitHub App as described below.
+
+#### Custom release command
+
+When the `release_command` input is set, the workflow runs the specified
+command. This allows for custom release steps to be executed before the version
+is tagged and the release is created, such as updating version numbers in files,
+generating changelogs, etc.
+
+Release command has access to the following environment variables:
+
+- `RELEASE_VERSION`: the new version calculated
+- `CURRENT_VERSION`: the previous version
+- `COMMIT_USERNAME`: the configured commit username (from `commit_username` input)
+- `COMMIT_EMAIL`: the configured commit email (from `commit_email` input)
+- `GH_TOKEN`: the authentication token (GitHub App installation token or `BOT_GITHUB_TOKEN`)
+- `TARGET_BRANCH`: the branch the release is created from (from `target_branch` input)
+
+If the release command needs Node.js (for example to run an `npx` tool), set the
+`node_version` input so the workflow runs
+[actions/setup-node](https://github.com/actions/setup-node) before executing the
+command; the step is skipped when the input is left empty.
 
 Changes produced by the release command are committed back to `target_branch`
 as a verified/signed commit (via [verified-bot-commit](#git-commit-and-push)),
@@ -2819,16 +2841,16 @@ jobs:
         with:
           release_type_override: ${{ inputs.release_type }}
           github_app_client_id: ${{ vars.GH_APP_CLIENT_ID }}
+          # github_app_workflows_permission: true # optional, set to true if the release command modifies workflow files
         secrets:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 ```
 
-Release command has access to the following environment variables:
-
-- `RELEASE_VERSION`: the new version calculated
-- `CURRENT_VERSION`: the previous version
-- `COMMIT_USERNAME`: the configured commit username (from `commit_username` input)
-- `COMMIT_EMAIL`: the configured commit email (from `commit_email` input)
+If the release command commits changes to files under `.github/workflows/`, also
+set `github_app_workflows_permission: true` so the minted token is granted the
+`workflows: write` permission; the GitHub API otherwise rejects commits that
+modify workflow files. The GitHub App must have the Workflows permission enabled
+in its configuration for this to be grantable.
 
 The `commit_username` / `commit_email` inputs are kept for backward compatibility
 and are only forwarded to the release command as the env vars above; the pushed


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4154
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/alfresco-build-tools/actions/runs/27811434243/job/82302467895

### Description

Switches the release flow to create commits that GitHub marks as verified via the `@gionn-net/verified-bot-commit` CLI instead of a local `git commit` + `git push`. The release script creates the candidate commit through the GitHub API; the CLI advances the local branch ref to the new commit, so the second pinning pass references the real candidate SHA. Package integrity is verified against a pinned `sha512` hash before `npx` runs it.

The reusable workflow gains two opt-in inputs: `node_version` (runs `setup-node` only when set) and `github_app_workflows_permission` (adds `workflows:write` to the GitHub App token, required because the release commit pins refs inside `.github/workflows/`). The release command also receives `GH_TOKEN` and `TARGET_BRANCH` env vars. The GitHub App token is kept rather than the default `GITHUB_TOKEN` because the latter cannot modify workflow files and its pushes do not trigger downstream workflows.
