### PR TITLE
OPSEXP-3938 Add setup-maven action

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -2,9 +2,8 @@ name: 'Setup Maven'
 description: 'Install a specific Apache Maven version and add it to the PATH.'
 inputs:
   version:
-    description: 'Version of Apache Maven to install (e.g. 3.9.9). If empty, uses the Maven version already on the PATH.'
-    required: false
-    default: ''
+    description: 'Version of Apache Maven to install (e.g. 3.9.9).'
+    required: true
 outputs:
   version:
     description: 'Version of Maven that is available on the PATH after this action runs.'
@@ -12,8 +11,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Maven
-      if: inputs.version != ''
+    - name: Resolve install paths
+      id: paths
       shell: bash
       env:
         MAVEN_VERSION: ${{ inputs.version }}
@@ -25,12 +24,30 @@ runs:
           exit 1
         fi
 
+        INSTALL_DIR="$RUNNER_TEMP/apache-maven/$MAVEN_VERSION"
+        echo "install-dir=$INSTALL_DIR" >> "$GITHUB_OUTPUT"
+        echo "maven-home=$INSTALL_DIR/apache-maven-${MAVEN_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Maven distribution
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ steps.paths.outputs.install-dir }}
+        key: apache-maven-${{ runner.os }}-${{ inputs.version }}
+
+    - name: Install Maven
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.version }}
+        INSTALL_DIR: ${{ steps.paths.outputs.install-dir }}
+        MAVEN_HOME: ${{ steps.paths.outputs.maven-home }}
+      run: |
+        set -euo pipefail
+
         MAJOR="${MAVEN_VERSION%%.*}"
-        INSTALL_DIR="$RUNNER_TOOL_CACHE/apache-maven/$MAVEN_VERSION"
         ARCHIVE="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
         BASE_URL="https://archive.apache.org/dist/maven/maven-${MAJOR}/${MAVEN_VERSION}/binaries"
 
-        if [[ ! -x "$INSTALL_DIR/apache-maven-${MAVEN_VERSION}/bin/mvn" ]]; then
+        if [[ ! -x "$MAVEN_HOME/bin/mvn" ]]; then
           mkdir -p "$INSTALL_DIR"
           cd "$RUNNER_TEMP"
 
@@ -52,9 +69,10 @@ runs:
 
           tar -xzf "$ARCHIVE" -C "$INSTALL_DIR"
           rm -f "$ARCHIVE" "${ARCHIVE}.sha512"
+        else
+          echo "Reusing cached Maven at $MAVEN_HOME"
         fi
 
-        MAVEN_HOME="$INSTALL_DIR/apache-maven-${MAVEN_VERSION}"
         echo "MAVEN_HOME=$MAVEN_HOME" >> "$GITHUB_ENV"
         echo "$MAVEN_HOME/bin" >> "$GITHUB_PATH"
 
@@ -74,7 +92,7 @@ runs:
         VERSION=$(mvn -v | awk '/^Apache Maven/ {print $3; exit}')
         echo "Detected Maven version on PATH: $VERSION"
 
-        if [[ -n "$REQUESTED_VERSION" && "$VERSION" != "$REQUESTED_VERSION" ]]; then
+        if [[ "$VERSION" != "$REQUESTED_VERSION" ]]; then
           echo "::error::Maven on PATH ($VERSION) does not match the requested version ($REQUESTED_VERSION). PATH updates may not have taken effect; check that no later step overwrites \$PATH or \$MAVEN_HOME."
           exit 1
         fi

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -7,13 +7,12 @@ inputs:
     default: ''
 outputs:
   version:
-    description: 'Version of Maven that was installed.'
-    value: ${{ steps.install.outputs.version }}
+    description: 'Version of Maven that is available on the PATH after this action runs.'
+    value: ${{ steps.detect.outputs.version }}
 runs:
   using: "composite"
   steps:
     - name: Install Maven
-      id: install
       if: inputs.version != ''
       shell: bash
       env:
@@ -29,22 +28,55 @@ runs:
         MAJOR="${MAVEN_VERSION%%.*}"
         INSTALL_DIR="$RUNNER_TOOL_CACHE/apache-maven/$MAVEN_VERSION"
         ARCHIVE="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
-        URL="https://archive.apache.org/dist/maven/maven-${MAJOR}/${MAVEN_VERSION}/binaries/${ARCHIVE}"
+        BASE_URL="https://archive.apache.org/dist/maven/maven-${MAJOR}/${MAVEN_VERSION}/binaries"
 
         if [[ ! -x "$INSTALL_DIR/apache-maven-${MAVEN_VERSION}/bin/mvn" ]]; then
           mkdir -p "$INSTALL_DIR"
-          echo "Downloading $URL ..."
-          curl -fsSL -o "$RUNNER_TEMP/$ARCHIVE" "$URL"
-          tar -xzf "$RUNNER_TEMP/$ARCHIVE" -C "$INSTALL_DIR"
-          rm -f "$RUNNER_TEMP/$ARCHIVE"
+          cd "$RUNNER_TEMP"
+
+          echo "Downloading ${BASE_URL}/${ARCHIVE} ..."
+          curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+
+          echo "Downloading ${BASE_URL}/${ARCHIVE}.sha512 ..."
+          curl -fsSL -o "${ARCHIVE}.sha512" "${BASE_URL}/${ARCHIVE}.sha512"
+
+          EXPECTED_SHA=$(awk '{print tolower($1); exit}' "${ARCHIVE}.sha512")
+          ACTUAL_SHA=$(shasum -a 512 "$ARCHIVE" | awk '{print tolower($1)}')
+          if [[ -z "$EXPECTED_SHA" || "$EXPECTED_SHA" != "$ACTUAL_SHA" ]]; then
+            echo "::error::SHA-512 checksum mismatch for ${ARCHIVE}."
+            echo "Expected: $EXPECTED_SHA"
+            echo "Actual:   $ACTUAL_SHA"
+            exit 1
+          fi
+          echo "SHA-512 checksum verified."
+
+          tar -xzf "$ARCHIVE" -C "$INSTALL_DIR"
+          rm -f "$ARCHIVE" "${ARCHIVE}.sha512"
         fi
 
         MAVEN_HOME="$INSTALL_DIR/apache-maven-${MAVEN_VERSION}"
         echo "MAVEN_HOME=$MAVEN_HOME" >> "$GITHUB_ENV"
         echo "$MAVEN_HOME/bin" >> "$GITHUB_PATH"
-        echo "version=$MAVEN_VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Verify Maven installation
-      if: inputs.version != ''
+    - name: Detect Maven version
+      id: detect
       shell: bash
-      run: mvn --version
+      env:
+        REQUESTED_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v mvn >/dev/null 2>&1; then
+          echo "::error::Maven is not available on the PATH."
+          exit 1
+        fi
+
+        VERSION=$(mvn -v | awk '/^Apache Maven/ {print $3; exit}')
+        echo "Detected Maven version on PATH: $VERSION"
+
+        if [[ -n "$REQUESTED_VERSION" && "$VERSION" != "$REQUESTED_VERSION" ]]; then
+          echo "::error::Maven on PATH ($VERSION) does not match the requested version ($REQUESTED_VERSION). PATH updates may not have taken effect; check that no later step overwrites \$PATH or \$MAVEN_HOME."
+          exit 1
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -11,10 +11,6 @@ inputs:
       parallel jobs that share the same key, or to force a fresh cache.
     required: false
     default: ''
-outputs:
-  version:
-    description: 'Version of Maven that is available on the PATH after this action runs.'
-    value: ${{ steps.detect.outputs.version }}
 runs:
   using: "composite"
   steps:
@@ -83,25 +79,6 @@ runs:
         echo "MAVEN_HOME=$MAVEN_HOME" >> "$GITHUB_ENV"
         echo "$MAVEN_HOME/bin" >> "$GITHUB_PATH"
 
-    - name: Detect Maven version
-      id: detect
+    - name: Verify Maven
       shell: bash
-      env:
-        REQUESTED_VERSION: ${{ inputs.version }}
-      run: |
-        set -euo pipefail
-
-        if ! command -v mvn >/dev/null 2>&1; then
-          echo "::error::Maven is not available on the PATH."
-          exit 1
-        fi
-
-        VERSION=$(mvn -v | awk '/^Apache Maven/ {print $3; exit}')
-        echo "Detected Maven version on PATH: $VERSION"
-
-        if [[ "$VERSION" != "$REQUESTED_VERSION" ]]; then
-          echo "::error::Maven on PATH ($VERSION) does not match the requested version ($REQUESTED_VERSION). PATH updates may not have taken effect; check that no later step overwrites \$PATH or \$MAVEN_HOME."
-          exit 1
-        fi
-
-        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      run: mvn --version

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -4,6 +4,13 @@ inputs:
   version:
     description: 'Version of Apache Maven to install (e.g. 3.9.9).'
     required: true
+  cache-key-suffix:
+    description: >
+      Optional suffix appended to the cache key
+      (apache-maven-<os>-<arch>-<version>-<suffix>). Use it to disambiguate
+      parallel jobs that share the same key, or to force a fresh cache.
+    required: false
+    default: ''
 outputs:
   version:
     description: 'Version of Maven that is available on the PATH after this action runs.'
@@ -32,7 +39,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.paths.outputs.install-dir }}
-        key: apache-maven-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+        key: apache-maven-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}${{ inputs.cache-key-suffix != '' && format('-{0}', inputs.cache-key-suffix) || '' }}
 
     - name: Install Maven
       shell: bash

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -1,0 +1,50 @@
+name: 'Setup Maven'
+description: 'Install a specific Apache Maven version and add it to the PATH.'
+inputs:
+  version:
+    description: 'Version of Apache Maven to install (e.g. 3.9.9). If empty, uses the Maven version already on the PATH.'
+    required: false
+    default: ''
+outputs:
+  version:
+    description: 'Version of Maven that was installed.'
+    value: ${{ steps.install.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Install Maven
+      id: install
+      if: inputs.version != ''
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! "$MAVEN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Invalid Maven version '$MAVEN_VERSION'. Expected format: <major>.<minor>.<patch> (e.g. 3.9.9)."
+          exit 1
+        fi
+
+        MAJOR="${MAVEN_VERSION%%.*}"
+        INSTALL_DIR="$RUNNER_TOOL_CACHE/apache-maven/$MAVEN_VERSION"
+        ARCHIVE="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+        URL="https://archive.apache.org/dist/maven/maven-${MAJOR}/${MAVEN_VERSION}/binaries/${ARCHIVE}"
+
+        if [[ ! -x "$INSTALL_DIR/apache-maven-${MAVEN_VERSION}/bin/mvn" ]]; then
+          mkdir -p "$INSTALL_DIR"
+          echo "Downloading $URL ..."
+          curl -fsSL -o "$RUNNER_TEMP/$ARCHIVE" "$URL"
+          tar -xzf "$RUNNER_TEMP/$ARCHIVE" -C "$INSTALL_DIR"
+          rm -f "$RUNNER_TEMP/$ARCHIVE"
+        fi
+
+        MAVEN_HOME="$INSTALL_DIR/apache-maven-${MAVEN_VERSION}"
+        echo "MAVEN_HOME=$MAVEN_HOME" >> "$GITHUB_ENV"
+        echo "$MAVEN_HOME/bin" >> "$GITHUB_PATH"
+        echo "version=$MAVEN_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Verify Maven installation
+      if: inputs.version != ''
+      shell: bash
+      run: mvn --version

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -32,7 +32,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.paths.outputs.install-dir }}
-        key: apache-maven-${{ runner.os }}-${{ inputs.version }}
+        key: apache-maven-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Install Maven
       shell: bash

--- a/.github/tests/actions/test-setup-maven/action.yml
+++ b/.github/tests/actions/test-setup-maven/action.yml
@@ -1,0 +1,30 @@
+name: Test setup-maven
+description: >
+  Just a test for setup-maven
+inputs:
+  expected-version:
+    description: 'Expected Maven version on the PATH'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Check Maven version on PATH
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.expected-version }}
+      run: |
+        set -euo pipefail
+        ACTUAL=$(mvn -v | awk '/^Apache Maven/ {print $3; exit}')
+        echo "Expected: $EXPECTED_VERSION"
+        echo "Actual:   $ACTUAL"
+        [ "$ACTUAL" = "$EXPECTED_VERSION" ]
+
+    - name: Check MAVEN_HOME points to the installed version
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.expected-version }}
+      run: |
+        set -euo pipefail
+        [ -n "${MAVEN_HOME:-}" ]
+        [ -x "$MAVEN_HOME/bin/mvn" ]
+        [[ "$MAVEN_HOME" == *"apache-maven-${EXPECTED_VERSION}" ]]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,20 +102,18 @@ jobs:
 
       #region Test setup-maven
       - uses: ./.github/actions/setup-maven
-        id: setup-maven-fixed-version
         with:
           version: 3.9.9
       - uses: ./.github/tests/actions/test-setup-maven
         with:
-          expected-version: ${{ steps.setup-maven-fixed-version.outputs.version }}
+          expected-version: 3.9.9
 
       - uses: ./.github/actions/setup-maven
-        id: setup-maven-other-version
         with:
           version: 3.8.8
       - uses: ./.github/tests/actions/test-setup-maven
         with:
-          expected-version: ${{ steps.setup-maven-other-version.outputs.version }}
+          expected-version: 3.8.8
 
       - name: Test setup-maven rejects invalid version
         id: setup-maven-invalid

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,22 @@ jobs:
 
       #region Test setup-maven
       - uses: ./.github/actions/setup-maven
+        id: setup-maven-noop
+      - name: Assert setup-maven no-op still reports the runner's Maven
+        env:
+          NOOP_VERSION: ${{ steps.setup-maven-noop.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$NOOP_VERSION" ]]; then
+            echo "setup-maven should populate outputs.version even when no version is requested"
+            exit 1
+          fi
+          if [[ ! "$NOOP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "outputs.version is not a valid Maven version: '$NOOP_VERSION'"
+            exit 1
+          fi
+
+      - uses: ./.github/actions/setup-maven
         id: setup-maven-fixed-version
         with:
           version: 3.9.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,36 @@ jobs:
           expected-version: ${{ steps.setup-helm-docs-fixed-version.outputs.version }}
       #endregion
 
+      #region Test setup-maven
+      - uses: ./.github/actions/setup-maven
+        id: setup-maven-fixed-version
+        with:
+          version: 3.9.9
+      - uses: ./.github/tests/actions/test-setup-maven
+        with:
+          expected-version: ${{ steps.setup-maven-fixed-version.outputs.version }}
+
+      - uses: ./.github/actions/setup-maven
+        id: setup-maven-other-version
+        with:
+          version: 3.8.8
+      - uses: ./.github/tests/actions/test-setup-maven
+        with:
+          expected-version: ${{ steps.setup-maven-other-version.outputs.version }}
+
+      - name: Test setup-maven rejects invalid version
+        id: setup-maven-invalid
+        continue-on-error: true
+        uses: ./.github/actions/setup-maven
+        with:
+          version: not-a-version
+      - name: Assert setup-maven failed on invalid version
+        if: steps.setup-maven-invalid.outcome != 'failure'
+        run: |
+          echo "setup-maven should fail when given an invalid version"
+          exit 1
+      #endregion
+
       - uses: ./.github/actions/setup-jx-release-version
       - uses: ./.github/actions/setup-kubepug
       - uses: ./.github/actions/rancher

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,22 +102,6 @@ jobs:
 
       #region Test setup-maven
       - uses: ./.github/actions/setup-maven
-        id: setup-maven-noop
-      - name: Assert setup-maven no-op still reports the runner's Maven
-        env:
-          NOOP_VERSION: ${{ steps.setup-maven-noop.outputs.version }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$NOOP_VERSION" ]]; then
-            echo "setup-maven should populate outputs.version even when no version is requested"
-            exit 1
-          fi
-          if [[ ! "$NOOP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "outputs.version is not a valid Maven version: '$NOOP_VERSION'"
-            exit 1
-          fi
-
-      - uses: ./.github/actions/setup-maven
         id: setup-maven-fixed-version
         with:
           version: 3.9.9

--- a/docs/README.md
+++ b/docs/README.md
@@ -2451,12 +2451,15 @@ Install the Kubernetes preupgrade checker and add it to the PATH.
 
 Install a specific Apache Maven version from the Apache archive and add it to
 the PATH. The distribution is cached across runs (via `actions/cache`, keyed on
-the requested version) to avoid re-downloading it every time.
+the OS, architecture and requested version) to avoid re-downloading it every
+time. Set `cache-key-suffix` to disambiguate parallel jobs that would otherwise
+share the same key, or to force a fresh cache.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-maven@v18.13.0
         with:
           version: "3.9.9"
+          # cache-key-suffix: "my-suffix" # optional
 ```
 
 ### setup-pysemver

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [setup-kcadm](#setup-kcadm)
   - [setup-kind](#setup-kind)
   - [setup-kubepug](#setup-kubepug)
+  - [setup-maven](#setup-maven)
   - [setup-pysemver](#setup-pysemver)
   - [setup-rancher-cli](#setup-rancher-cli)
   - [setup-terraform-docs](#setup-terraform-docs)
@@ -2444,6 +2445,18 @@ Install the Kubernetes preupgrade checker and add it to the PATH.
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-kubepug@v18.13.0
         with:
           version: "1.3.2"
+```
+
+### setup-maven
+
+Install a specific Apache Maven version from the Apache archive and add it to
+the PATH. When the `version` input is empty, the action is a no-op and the
+Maven version already available on the runner is used.
+
+```yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-maven@v18.13.0
+        with:
+          version: "3.9.9"
 ```
 
 ### setup-pysemver

--- a/docs/README.md
+++ b/docs/README.md
@@ -2450,8 +2450,8 @@ Install the Kubernetes preupgrade checker and add it to the PATH.
 ### setup-maven
 
 Install a specific Apache Maven version from the Apache archive and add it to
-the PATH. When the `version` input is empty, the action is a no-op and uses the
-Maven version already available on the runner (the step fails if `mvn` is not on the PATH).
+the PATH. The distribution is cached across runs (via `actions/cache`, keyed on
+the requested version) to avoid re-downloading it every time.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-maven@v18.13.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -2450,8 +2450,8 @@ Install the Kubernetes preupgrade checker and add it to the PATH.
 ### setup-maven
 
 Install a specific Apache Maven version from the Apache archive and add it to
-the PATH. When the `version` input is empty, the action is a no-op and the
-Maven version already available on the runner is used.
+the PATH. When the `version` input is empty, the action is a no-op and uses the
+Maven version already available on the runner (the step fails if `mvn` is not on the PATH).
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-maven@v18.13.0


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-3938
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->
Why

  We need a reliable, pinned way to provision a chosen Maven version on runners, independent of whatever Maven the runner image happens to ship.

  How it works

  - Input version (required) — the Maven version to install, e.g. 3.9.9. Validated against <major>.<minor>.<patch>; an invalid value fails fast
  with a clear error.
  - Download + integrity check — fetches apache-maven-<version>-bin.tar.gz from archive.apache.org and verifies its SHA-512 checksum before
  extracting. Refuses to proceed on mismatch.
  - Install location — extracts under $RUNNER_TEMP/apache-maven/<version>, exports MAVEN_HOME, and prepends bin/ to the PATH.
  - Caching — caches the distribution via actions/cache, keyed on apache-maven-<os>-<arch>-<version>, so it isn't re-downloaded on every run. On
  a cache hit the download/verify is skipped.
  - Input cache-key-suffix (optional) — appended to the cache key to disambiguate parallel jobs that would otherwise share a key, or to force a
  fresh cache.
  - Verify — runs mvn --version at the end as a sanity check that the install and PATH wiring took effect.

  Tests

  - New test-setup-maven helper action asserts the resolved mvn version matches the requested one and that MAVEN_HOME points at the installed
  version.
  - test.yml exercises: install 3.9.9, install 3.8.8, and rejection of an invalid version string.

  Docs

  - Added a setup-maven section to docs/README.md with a usage example.