### PR TITLE
Fix broken pipe in get-commit-message with large messages

### DIFF
--- a/.github/actions/get-commit-message/action.yml
+++ b/.github/actions/get-commit-message/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         MSG=$(git log --format=%B -n 1 "$CURRENT_SHA")
         if [ "${{ inputs.header-only }}" = "true" ]; then
-          MSG=$(echo "$MSG" | head -n 1)
+          MSG=${MSG%%$'\n'*}
         fi
 
         echo "COMMIT_MESSAGE<<$EOF" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,8 +301,13 @@ jobs:
           echo "Full commit message header (env): $COMMIT_MSG_HEADER_ENV"
           # header-only must be exactly the first line of the full message
           EXPECTED=${COMMIT_MSG_OUTPUT%%$'\n'*}
-          [ "$COMMIT_MSG_HEADER_OUTPUT" = "$EXPECTED" ] || { echo "::error::header output '$COMMIT_MSG_HEADER_OUTPUT' does not match first line '$EXPECTED'"; exit 1; }
-          [ "$COMMIT_MSG_HEADER_ENV" = "$EXPECTED" ] || { echo "::error::header env '$COMMIT_MSG_HEADER_ENV' does not match first line '$EXPECTED'"; exit 1; }
+          if [ "$COMMIT_MSG_HEADER_OUTPUT" != "$EXPECTED" ] || [ "$COMMIT_MSG_HEADER_ENV" != "$EXPECTED" ]; then
+            echo "Expected first line: $EXPECTED"
+            echo "Header output:       $COMMIT_MSG_HEADER_OUTPUT"
+            echo "Header env:          $COMMIT_MSG_HEADER_ENV"
+            echo "::error::header-only commit message does not match first line of full message"
+            exit 1
+          fi
       # endregion
 
       - uses: ./.github/actions/get-branch-name-v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,6 +283,8 @@ jobs:
         run: |
           echo "Full commit message (output): $COMMIT_MSG_OUTPUT"
           echo "Full commit message (env): $COMMIT_MSG_ENV"
+          [ -n "$COMMIT_MSG_OUTPUT" ] || { echo "::error::full commit message output is empty"; exit 1; }
+          [ -n "$COMMIT_MSG_ENV" ] || { echo "::error::full commit message env is empty"; exit 1; }
 
       - uses: ./.github/actions/get-commit-message
         id: get-commit-message-header-only
@@ -291,11 +293,16 @@ jobs:
 
       - name: Test commit message header
         env:
+          COMMIT_MSG_OUTPUT: ${{ steps.get-full-commit-message.outputs.COMMIT_MESSAGE }}
           COMMIT_MSG_HEADER_OUTPUT: ${{ steps.get-commit-message-header-only.outputs.COMMIT_MESSAGE }}
           COMMIT_MSG_HEADER_ENV: ${{ env.COMMIT_MESSAGE }}
         run: |
           echo "Full commit message header (output): $COMMIT_MSG_HEADER_OUTPUT"
           echo "Full commit message header (env): $COMMIT_MSG_HEADER_ENV"
+          # header-only must be exactly the first line of the full message
+          EXPECTED=${COMMIT_MSG_OUTPUT%%$'\n'*}
+          [ "$COMMIT_MSG_HEADER_OUTPUT" = "$EXPECTED" ] || { echo "::error::header output '$COMMIT_MSG_HEADER_OUTPUT' does not match first line '$EXPECTED'"; exit 1; }
+          [ "$COMMIT_MSG_HEADER_ENV" = "$EXPECTED" ] || { echo "::error::header env '$COMMIT_MSG_HEADER_ENV' does not match first line '$EXPECTED'"; exit 1; }
       # endregion
 
       - uses: ./.github/actions/get-branch-name-v2


### PR DESCRIPTION

<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title):
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

<!-- Explain your changes -->

The header-only branch piped the full commit message through `head -n 1`. Under bash `set -eo pipefail` (the GitHub Actions default), a large commit message caused `echo` to receive a broken pipe once `head` closed the pipe, failing the step with exit code 1.

Extract the first line with parameter expansion instead, and add assertions to the test workflow so header-only output matches the first line of the full message.

https://github.com/Alfresco/alfresco-build-tools/actions/runs/28576094027/job/84727715413