### PR TITLE
OPSEXP-3962 setup-kind: bump default traefik chart to GA 41.0.2

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -31,7 +31,7 @@ inputs:
     description: |
       The Traefik helm chart version to install. Check available versions on
       https://artifacthub.io/packages/helm/traefik/traefik
-    default: "39.0.0"
+    default: "41.0.2"
   cloud-provider-kind-enabled:
     description: |
       Whether to install and run cloud-provider-kind alongside the KinD cluster.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2417,10 +2417,8 @@ LoadBalancer support.
           ingress-nginx-ref: controller-v1.8.2
 
           # Traefik (requires cloud-provider-kind):
-          #   traefik-enabled: 'true'
-          #   traefik-chart-version: 39.0.0
           traefik-enabled: 'true'
-          traefik-chart-version: 39.0.0 # optional
+          traefik-chart-version: 41.0.2 # optional
           cloud-provider-kind-enabled: 'true'
           cloud-provider-kind-version: 0.10.0 # optional
 


### PR DESCRIPTION
Now that the Traefik v40+ helm chart is GA, bump the `setup-kind` action default `traefik-chart-version` from `39.0.0` to `41.0.2`. The action already selects the `kubernetesIngressNGINX` provider name for chart major versions >= 40, so consumers picking up the new default get the GA provider naming automatically.

Also tidied the docs example to stop repeating `traefik-chart-version` (it was shown both as a commented example and as an active value).

OPSEXP-3962