### PR TITLE
OPSEXP-4141 Use GitHub API for updatecli commits to get verified commits

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup-updatecli
 
       - name: Run Updatecli
-        run: updatecli apply -c .updatecli/templates/github_releases.yaml -v .updatecli/values/github_releases/${{ matrix.file }}
+        run: updatecli pipeline apply -c .updatecli/templates/github_releases.yaml -v .updatecli/values/github_releases/${{ matrix.file }}
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATECLI_USERNAME: ${{ vars.BOT_GITHUB_USERNAME }}

--- a/.updatecli/templates/github_releases.yaml
+++ b/.updatecli/templates/github_releases.yaml
@@ -13,6 +13,7 @@ scms:
       owner: '{{ requiredEnv "UPDATECLI_REPO_OWNER" }}'
       repository: '{{ requiredEnv "UPDATECLI_REPO_NAME" }}'
       branch: '{{ requiredEnv "UPDATECLI_REPO_BRANCH" }}'
+      commitusingapi: true
       commitmessage:
         type: '{{ .github.prefix }}'
         message: '{{ .github.message }}'


### PR DESCRIPTION
Add `commitusingapi: true` under the `github` scm spec in the updatecli GitHub Releases template so updatecli commits via the GitHub API rather than pushing raw git commits. This makes the resulting commits verified, using the existing `GITHUB_TOKEN`.

OPSEXP-4141