### PR TITLE
AAE-47025 Add check-pr-description composite action

### DIFF
--- a/.github/actions/check-pr-description/action.yml
+++ b/.github/actions/check-pr-description/action.yml
@@ -1,0 +1,61 @@
+name: check-pr-description
+
+description: Fail a pull request when its description is missing or shorter than a configurable minimum word count.
+
+inputs:
+  min-words:
+    description: Minimum number of words required in the PR description after HTML comments are stripped.
+    required: false
+    default: "15"
+  skip-authors:
+    description: Space-separated shell glob patterns of PR author logins to skip, in addition to any '*[bot]' author.
+    required: false
+    default: "dependabot renovate alfresco-build*"
+
+runs:
+  using: composite
+  steps:
+    - name: Skip drafts and bot authors
+      id: gate
+      shell: bash
+      env:
+        AUTHOR: ${{ github.event.pull_request.user.login }}
+        IS_DRAFT: ${{ github.event.pull_request.draft }}
+        SKIP_AUTHORS: ${{ inputs.skip-authors }}
+      run: |
+        set -euo pipefail
+        if [ "${IS_DRAFT}" = "true" ]; then
+          echo "Skipping draft PR."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        skip=false
+        case "${AUTHOR}" in
+          *"[bot]") skip=true ;;
+        esac
+        for pattern in ${SKIP_AUTHORS}; do
+          # shellcheck disable=SC2254
+          case "${AUTHOR}" in
+            ${pattern}) skip=true ;;
+          esac
+        done
+        if [ "${skip}" = "true" ]; then
+          echo "Skipping author: ${AUTHOR}"
+        fi
+        echo "skip=${skip}" >> "$GITHUB_OUTPUT"
+
+    - name: Check word count
+      if: steps.gate.outputs.skip != 'true'
+      shell: bash
+      env:
+        BODY: ${{ github.event.pull_request.body }}
+        MIN_WORDS: ${{ inputs.min-words }}
+      run: |
+        set -euo pipefail
+        stripped=$(printf '%s' "${BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
+        words=$(printf '%s' "${stripped}" | wc -w | tr -d ' ')
+        echo "PR description word count: ${words} (minimum: ${MIN_WORDS})"
+        if [ "${words}" -lt "${MIN_WORDS}" ]; then
+          echo "::error title=PR description too short::PR description has ${words} words; at least ${MIN_WORDS} are required. Please describe what changed and why."
+          exit 1
+        fi

--- a/.github/actions/check-pr-description/action.yml
+++ b/.github/actions/check-pr-description/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Space-separated shell glob patterns of PR author logins to skip, in addition to any '*[bot]' author.
     required: false
     default: "dependabot renovate alfresco-build*"
+  skip-branches:
+    description: Space-separated shell glob patterns of head branch names to skip (automated/bot PRs). Matched against github.head_ref.
+    required: false
+    default: "dependabot/* renovate/* updatecli* image-update* flux-* pr-* release-please--* changeset-release/* snyk-* whitesource* mend-* automated-* automation/*"
   pr-body:
     description: Pull request body to check. Defaults to the triggering pull_request event body; override mainly for testing.
     required: false
@@ -27,17 +31,23 @@ inputs:
     description: Whether the pull request is a draft. Defaults to the triggering pull_request event draft flag; override mainly for testing.
     required: false
     default: ""
+  pr-branch:
+    description: Head branch name of the pull request. Defaults to the triggering pull_request head ref; override mainly for testing.
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
-    - name: Skip drafts and bot authors
+    - name: Skip drafts, bot authors and automated branches
       id: gate
       shell: bash
       env:
         AUTHOR: ${{ inputs.pr-author || github.event.pull_request.user.login }}
         IS_DRAFT: ${{ inputs.pr-draft || github.event.pull_request.draft }}
+        HEAD_BRANCH: ${{ inputs.pr-branch || github.head_ref }}
         SKIP_AUTHORS: ${{ inputs.skip-authors }}
+        SKIP_BRANCHES: ${{ inputs.skip-branches }}
       run: |
         set -euo pipefail
         if [ "${IS_DRAFT}" = "true" ]; then
@@ -49,8 +59,9 @@ runs:
         case "${AUTHOR}" in
           *"[bot]") skip=true ;;
         esac
-        # Disable pathname expansion so skip-authors patterns (e.g. alfresco-build*)
-        # are not expanded against the workspace and are matched literally by case.
+        # Disable pathname expansion so skip-authors / skip-branches patterns
+        # (e.g. alfresco-build*, dependabot/*) are matched literally by case and
+        # are not expanded against the workspace.
         set -f
         for pattern in ${SKIP_AUTHORS}; do
           # shellcheck disable=SC2254
@@ -58,9 +69,15 @@ runs:
             ${pattern}) skip=true ;;
           esac
         done
+        for pattern in ${SKIP_BRANCHES}; do
+          # shellcheck disable=SC2254
+          case "${HEAD_BRANCH}" in
+            ${pattern}) skip=true ;;
+          esac
+        done
         set +f
         if [ "${skip}" = "true" ]; then
-          echo "Skipping author: ${AUTHOR}"
+          echo "Skipping automated PR (author=${AUTHOR}, branch=${HEAD_BRANCH})."
         fi
         echo "skip=${skip}" >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/check-pr-description/action.yml
+++ b/.github/actions/check-pr-description/action.yml
@@ -19,124 +19,19 @@ inputs:
     description: Space-separated shell glob patterns of head branch names to skip (automated/bot PRs). Matched against github.head_ref.
     required: false
     default: "dependabot/* renovate/* updatecli* image-update* flux-* pr-* release-please--* changeset-release/* snyk-* whitesource* mend-* automated-* automation/*"
-  pr-body:
-    description: Pull request body to check. Defaults to the triggering pull_request event body; override mainly for testing.
-    required: false
-    default: ""
-  pr-author:
-    description: Pull request author login. Defaults to the triggering pull_request event author; override mainly for testing.
-    required: false
-    default: ""
-  pr-draft:
-    description: Whether the pull request is a draft. Defaults to the triggering pull_request event draft flag; override mainly for testing.
-    required: false
-    default: ""
-  pr-branch:
-    description: Head branch name of the pull request. Defaults to the triggering pull_request head ref; override mainly for testing.
-    required: false
-    default: ""
 
 runs:
   using: composite
   steps:
-    - name: Skip drafts, bot authors and automated branches
-      id: gate
+    - name: Check PR description
       shell: bash
       env:
-        AUTHOR: ${{ inputs.pr-author || github.event.pull_request.user.login }}
-        IS_DRAFT: ${{ inputs.pr-draft || github.event.pull_request.draft }}
-        HEAD_BRANCH: ${{ inputs.pr-branch || github.head_ref }}
-        SKIP_AUTHORS: ${{ inputs.skip-authors }}
-        SKIP_BRANCHES: ${{ inputs.skip-branches }}
-      run: |
-        set -euo pipefail
-        if [ "${IS_DRAFT}" = "true" ]; then
-          echo "Skipping draft PR."
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        skip=false
-        case "${AUTHOR}" in
-          *"[bot]") skip=true ;;
-        esac
-        # Disable pathname expansion so skip-authors / skip-branches patterns
-        # (e.g. alfresco-build*, dependabot/*) are matched literally by case and
-        # are not expanded against the workspace.
-        set -f
-        for pattern in ${SKIP_AUTHORS}; do
-          # shellcheck disable=SC2254
-          case "${AUTHOR}" in
-            ${pattern}) skip=true ;;
-          esac
-        done
-        for pattern in ${SKIP_BRANCHES}; do
-          # shellcheck disable=SC2254
-          case "${HEAD_BRANCH}" in
-            ${pattern}) skip=true ;;
-          esac
-        done
-        set +f
-        if [ "${skip}" = "true" ]; then
-          echo "Skipping automated PR (author=${AUTHOR}, branch=${HEAD_BRANCH})."
-        fi
-        echo "skip=${skip}" >> "$GITHUB_OUTPUT"
-
-    - name: Check description
-      if: steps.gate.outputs.skip != 'true'
-      shell: bash
-      env:
-        BODY: ${{ inputs.pr-body || github.event.pull_request.body }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_DRAFT: ${{ github.event.pull_request.draft }}
+        PR_BRANCH: ${{ github.head_ref }}
         MIN_CHARS: ${{ inputs.min-chars }}
         MIN_WORDS: ${{ inputs.min-words }}
-      run: |
-        set -euo pipefail
-        if ! printf '%s' "${MIN_CHARS}" | grep -Eq '^[0-9]+$'; then
-          echo "::error title=Invalid min-chars::min-chars must be a non-negative integer, got '${MIN_CHARS}'."
-          exit 1
-        fi
-        if ! printf '%s' "${MIN_WORDS}" | grep -Eq '^[0-9]+$'; then
-          echo "::error title=Invalid min-words::min-words must be a non-negative integer, got '${MIN_WORDS}'."
-          exit 1
-        fi
-
-        # Remove PR-template HTML comments first.
-        body=$(printf '%s' "${BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
-
-        # Any non-whitespace content at all? Distinguishes empty from link-only.
-        raw=$(printf '%s' "${body}" | tr -d '[:space:]')
-
-        # Meaningful prose: keep Markdown link text but drop the URL target,
-        # drop autolinks and bare URLs, drop Jira ticket keys (e.g. AAE-1234),
-        # then collapse whitespace and trim.
-        meaningful=$(printf '%s' "${body}" | perl -0777 -pe '
-          s/\[([^\]]*)\]\([^)]*\)/$1/g;
-          s/<https?:\/\/[^>]*>//g;
-          s{https?://\S+}{}g;
-          s/\b[A-Z][A-Z0-9]+-\d+\b//g;
-          s/[[:space:]]+/ /g;
-          s/^\s+//;
-          s/\s+$//;
-        ')
-
-        chars=$(printf '%s' "${meaningful}" | wc -m | tr -d ' ')
-        words=$(printf '%s' "${meaningful}" | wc -w | tr -d ' ')
-        echo "Meaningful description: ${chars} characters (min ${MIN_CHARS}), ${words} words (min ${MIN_WORDS})."
-
-        if [ -z "${meaningful}" ]; then
-          if [ -n "${raw}" ]; then
-            echo "::error title=PR description is only a link::A bare Jira ticket reference or URL is not a description. Add a sentence describing what changed and why."
-          else
-            echo "::error title=PR description is empty::Add a description of what changed and why."
-          fi
-          exit 1
-        fi
-
-        if [ "${chars}" -lt "${MIN_CHARS}" ]; then
-          echo "::error title=PR description too short::The description has ${chars} meaningful characters (links and ticket references are excluded); at least ${MIN_CHARS} are required. Describe what changed and why."
-          exit 1
-        fi
-
-        if [ "${words}" -lt "${MIN_WORDS}" ]; then
-          echo "::error title=PR description too short::The description has ${words} meaningful words (links and ticket references are excluded); at least ${MIN_WORDS} are required. Describe what changed and why."
-          exit 1
-        fi
+        SKIP_AUTHORS: ${{ inputs.skip-authors }}
+        SKIP_BRANCHES: ${{ inputs.skip-branches }}
+      run: ${{ github.action_path }}/check-pr-description.sh

--- a/.github/actions/check-pr-description/action.yml
+++ b/.github/actions/check-pr-description/action.yml
@@ -11,6 +11,18 @@ inputs:
     description: Space-separated shell glob patterns of PR author logins to skip, in addition to any '*[bot]' author.
     required: false
     default: "dependabot renovate alfresco-build*"
+  pr-body:
+    description: Pull request body to check. Defaults to the triggering pull_request event body; override mainly for testing.
+    required: false
+    default: ""
+  pr-author:
+    description: Pull request author login. Defaults to the triggering pull_request event author; override mainly for testing.
+    required: false
+    default: ""
+  pr-draft:
+    description: Whether the pull request is a draft. Defaults to the triggering pull_request event draft flag; override mainly for testing.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -19,8 +31,8 @@ runs:
       id: gate
       shell: bash
       env:
-        AUTHOR: ${{ github.event.pull_request.user.login }}
-        IS_DRAFT: ${{ github.event.pull_request.draft }}
+        AUTHOR: ${{ inputs.pr-author || github.event.pull_request.user.login }}
+        IS_DRAFT: ${{ inputs.pr-draft || github.event.pull_request.draft }}
         SKIP_AUTHORS: ${{ inputs.skip-authors }}
       run: |
         set -euo pipefail
@@ -33,12 +45,16 @@ runs:
         case "${AUTHOR}" in
           *"[bot]") skip=true ;;
         esac
+        # Disable pathname expansion so skip-authors patterns (e.g. alfresco-build*)
+        # are not expanded against the workspace and are matched literally by case.
+        set -f
         for pattern in ${SKIP_AUTHORS}; do
           # shellcheck disable=SC2254
           case "${AUTHOR}" in
             ${pattern}) skip=true ;;
           esac
         done
+        set +f
         if [ "${skip}" = "true" ]; then
           echo "Skipping author: ${AUTHOR}"
         fi
@@ -48,10 +64,14 @@ runs:
       if: steps.gate.outputs.skip != 'true'
       shell: bash
       env:
-        BODY: ${{ github.event.pull_request.body }}
+        BODY: ${{ inputs.pr-body || github.event.pull_request.body }}
         MIN_WORDS: ${{ inputs.min-words }}
       run: |
         set -euo pipefail
+        if ! printf '%s' "${MIN_WORDS}" | grep -Eq '^[0-9]+$'; then
+          echo "::error title=Invalid min-words::min-words must be a non-negative integer, got '${MIN_WORDS}'."
+          exit 1
+        fi
         stripped=$(printf '%s' "${BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
         words=$(printf '%s' "${stripped}" | wc -w | tr -d ' ')
         echo "PR description word count: ${words} (minimum: ${MIN_WORDS})"

--- a/.github/actions/check-pr-description/action.yml
+++ b/.github/actions/check-pr-description/action.yml
@@ -1,12 +1,16 @@
 name: check-pr-description
 
-description: Fail a pull request when its description is missing or shorter than a configurable minimum word count.
+description: Fail a pull request when its description is missing, too short, or only a ticket/URL reference.
 
 inputs:
-  min-words:
-    description: Minimum number of words required in the PR description after HTML comments are stripped.
+  min-chars:
+    description: Minimum number of meaningful characters required in the PR description (HTML comments, URLs and Jira ticket keys are excluded from the count).
     required: false
     default: "15"
+  min-words:
+    description: Minimum number of meaningful words required in the PR description (same exclusions as min-chars). Guards against single-token padding.
+    required: false
+    default: "3"
   skip-authors:
     description: Space-separated shell glob patterns of PR author logins to skip, in addition to any '*[bot]' author.
     required: false
@@ -60,22 +64,62 @@ runs:
         fi
         echo "skip=${skip}" >> "$GITHUB_OUTPUT"
 
-    - name: Check word count
+    - name: Check description
       if: steps.gate.outputs.skip != 'true'
       shell: bash
       env:
         BODY: ${{ inputs.pr-body || github.event.pull_request.body }}
+        MIN_CHARS: ${{ inputs.min-chars }}
         MIN_WORDS: ${{ inputs.min-words }}
       run: |
         set -euo pipefail
+        if ! printf '%s' "${MIN_CHARS}" | grep -Eq '^[0-9]+$'; then
+          echo "::error title=Invalid min-chars::min-chars must be a non-negative integer, got '${MIN_CHARS}'."
+          exit 1
+        fi
         if ! printf '%s' "${MIN_WORDS}" | grep -Eq '^[0-9]+$'; then
           echo "::error title=Invalid min-words::min-words must be a non-negative integer, got '${MIN_WORDS}'."
           exit 1
         fi
-        stripped=$(printf '%s' "${BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
-        words=$(printf '%s' "${stripped}" | wc -w | tr -d ' ')
-        echo "PR description word count: ${words} (minimum: ${MIN_WORDS})"
+
+        # Remove PR-template HTML comments first.
+        body=$(printf '%s' "${BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
+
+        # Any non-whitespace content at all? Distinguishes empty from link-only.
+        raw=$(printf '%s' "${body}" | tr -d '[:space:]')
+
+        # Meaningful prose: keep Markdown link text but drop the URL target,
+        # drop autolinks and bare URLs, drop Jira ticket keys (e.g. AAE-1234),
+        # then collapse whitespace and trim.
+        meaningful=$(printf '%s' "${body}" | perl -0777 -pe '
+          s/\[([^\]]*)\]\([^)]*\)/$1/g;
+          s/<https?:\/\/[^>]*>//g;
+          s{https?://\S+}{}g;
+          s/\b[A-Z][A-Z0-9]+-\d+\b//g;
+          s/[[:space:]]+/ /g;
+          s/^\s+//;
+          s/\s+$//;
+        ')
+
+        chars=$(printf '%s' "${meaningful}" | wc -m | tr -d ' ')
+        words=$(printf '%s' "${meaningful}" | wc -w | tr -d ' ')
+        echo "Meaningful description: ${chars} characters (min ${MIN_CHARS}), ${words} words (min ${MIN_WORDS})."
+
+        if [ -z "${meaningful}" ]; then
+          if [ -n "${raw}" ]; then
+            echo "::error title=PR description is only a link::A bare Jira ticket reference or URL is not a description. Add a sentence describing what changed and why."
+          else
+            echo "::error title=PR description is empty::Add a description of what changed and why."
+          fi
+          exit 1
+        fi
+
+        if [ "${chars}" -lt "${MIN_CHARS}" ]; then
+          echo "::error title=PR description too short::The description has ${chars} meaningful characters (links and ticket references are excluded); at least ${MIN_CHARS} are required. Describe what changed and why."
+          exit 1
+        fi
+
         if [ "${words}" -lt "${MIN_WORDS}" ]; then
-          echo "::error title=PR description too short::PR description has ${words} words; at least ${MIN_WORDS} are required. Please describe what changed and why."
+          echo "::error title=PR description too short::The description has ${words} meaningful words (links and ticket references are excluded); at least ${MIN_WORDS} are required. Describe what changed and why."
           exit 1
         fi

--- a/.github/actions/check-pr-description/check-pr-description.sh
+++ b/.github/actions/check-pr-description/check-pr-description.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+MIN_CHARS="${MIN_CHARS:-15}"
+MIN_WORDS="${MIN_WORDS:-3}"
+SKIP_AUTHORS="${SKIP_AUTHORS:-}"
+SKIP_BRANCHES="${SKIP_BRANCHES:-}"
+PR_BODY="${PR_BODY:-}"
+PR_AUTHOR="${PR_AUTHOR:-}"
+PR_DRAFT="${PR_DRAFT:-}"
+PR_BRANCH="${PR_BRANCH:-}"
+
+if [ "${PR_DRAFT}" = "true" ]; then
+  echo "Skipping draft PR."
+  exit 0
+fi
+
+skip=false
+case "${PR_AUTHOR}" in
+  *"[bot]") skip=true ;;
+esac
+
+# Disable pathname expansion so skip-authors / skip-branches patterns
+# (e.g. alfresco-build*, dependabot/*) are matched literally by case and
+# are not expanded against the workspace.
+set -f
+for pattern in ${SKIP_AUTHORS}; do
+  # shellcheck disable=SC2254
+  case "${PR_AUTHOR}" in
+    ${pattern}) skip=true ;;
+  esac
+done
+for pattern in ${SKIP_BRANCHES}; do
+  # shellcheck disable=SC2254
+  case "${PR_BRANCH}" in
+    ${pattern}) skip=true ;;
+  esac
+done
+set +f
+
+if [ "${skip}" = "true" ]; then
+  echo "Skipping automated PR (author=${PR_AUTHOR}, branch=${PR_BRANCH})."
+  exit 0
+fi
+
+if ! printf '%s' "${MIN_CHARS}" | grep -Eq '^[0-9]+$'; then
+  echo "::error title=Invalid min-chars::min-chars must be a non-negative integer, got '${MIN_CHARS}'."
+  exit 1
+fi
+if ! printf '%s' "${MIN_WORDS}" | grep -Eq '^[0-9]+$'; then
+  echo "::error title=Invalid min-words::min-words must be a non-negative integer, got '${MIN_WORDS}'."
+  exit 1
+fi
+
+# Remove PR-template HTML comments first.
+body=$(printf '%s' "${PR_BODY}" | perl -0777 -pe 's/<!--.*?-->//gs')
+
+# Any non-whitespace content at all? Distinguishes empty from link-only.
+raw=$(printf '%s' "${body}" | tr -d '[:space:]')
+
+# Meaningful prose: keep Markdown link text but drop the URL target,
+# drop autolinks and bare URLs, drop Jira ticket keys (e.g. AAE-1234),
+# then collapse whitespace and trim.
+meaningful=$(printf '%s' "${body}" | perl -0777 -pe '
+  s/\[([^\]]*)\]\([^)]*\)/$1/g;
+  s/<https?:\/\/[^>]*>//g;
+  s{https?://\S+}{}g;
+  s/\b[A-Z][A-Z0-9]+-\d+\b//g;
+  s/[[:space:]]+/ /g;
+  s/^\s+//;
+  s/\s+$//;
+')
+
+chars=$(printf '%s' "${meaningful}" | wc -m | tr -d ' ')
+words=$(printf '%s' "${meaningful}" | wc -w | tr -d ' ')
+echo "Meaningful description: ${chars} characters (min ${MIN_CHARS}), ${words} words (min ${MIN_WORDS})."
+
+if [ -z "${meaningful}" ]; then
+  if [ -n "${raw}" ]; then
+    echo "::error title=PR description is only a link::A bare Jira ticket reference or URL is not a description. Add a sentence describing what changed and why."
+  else
+    echo "::error title=PR description is empty::Add a description of what changed and why."
+  fi
+  exit 1
+fi
+
+if [ "${chars}" -lt "${MIN_CHARS}" ]; then
+  echo "::error title=PR description too short::The description has ${chars} meaningful characters (links and ticket references are excluded); at least ${MIN_CHARS} are required. Describe what changed and why."
+  exit 1
+fi
+
+if [ "${words}" -lt "${MIN_WORDS}" ]; then
+  echo "::error title=PR description too short::The description has ${words} meaningful words (links and ticket references are excluded); at least ${MIN_WORDS} are required. Describe what changed and why."
+  exit 1
+fi

--- a/.github/actions/check-pr-description/tests/check-pr-description.bats
+++ b/.github/actions/check-pr-description/tests/check-pr-description.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+
+setup() {
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    SCRIPT="$DIR/../check-pr-description.sh"
+    export MIN_CHARS=15
+    export MIN_WORDS=3
+    export SKIP_AUTHORS="dependabot renovate alfresco-build*"
+    export SKIP_BRANCHES="dependabot/* renovate/* updatecli* image-update* flux-* pr-* release-please--* changeset-release/* snyk-* whitesource* mend-* automated-* automation/*"
+    export PR_AUTHOR="octocat"
+    export PR_DRAFT="false"
+    export PR_BRANCH="feature/foo"
+}
+
+@test "passes on a meaningful description" {
+    export PR_BODY="Fixes the login redirect loop on session expiry."
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "keeps markdown link text as meaningful content" {
+    export PR_BODY="Refactor the [token refresh](https://example.com/docs) handling to avoid races."
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "fails on an empty description" {
+    export PR_BODY=""
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"PR description is empty"* ]]
+}
+
+@test "fails when only PR-template HTML comments are present" {
+    export PR_BODY="<!-- describe your change here -->"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"PR description is empty"* ]]
+}
+
+@test "fails on a ticket-link-only description" {
+    export PR_BODY="https://hyland.atlassian.net/browse/AAE-1234"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"only a link"* ]]
+}
+
+@test "fails on a bare ticket key description" {
+    export PR_BODY="AAE-1234"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"only a link"* ]]
+}
+
+@test "fails when the description is too short in characters" {
+    export PR_BODY="typo fix here"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"too short"* ]]
+}
+
+@test "fails when the description has too few words" {
+    export PR_BODY="aaaaaaaaaaaaaaaaaaaa"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"too short"* ]]
+}
+
+@test "skips draft PRs" {
+    export PR_DRAFT="true"
+    export PR_BODY="short"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping draft PR"* ]]
+}
+
+@test "skips bot authors" {
+    export PR_AUTHOR="dependabot[bot]"
+    export PR_BODY="short"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping automated PR"* ]]
+}
+
+@test "skips authors matching a skip-authors glob" {
+    export PR_AUTHOR="alfresco-build-user"
+    export PR_BODY="x"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping automated PR"* ]]
+}
+
+@test "skips head branches matching a skip-branches glob" {
+    export PR_AUTHOR="svc-account"
+    export PR_BRANCH="dependabot/terraform/aws-5.0"
+    export PR_BODY="x"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping automated PR"* ]]
+}
+
+@test "does not skip regular authors and branches" {
+    export PR_AUTHOR="octocat"
+    export PR_BRANCH="feature/login-fix"
+    export PR_BODY="x"
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+}
+
+@test "fails with a clear error on non-integer min-chars" {
+    export MIN_CHARS="abc"
+    export PR_BODY="Fixes the login redirect loop on session expiry."
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid min-chars"* ]]
+}
+
+@test "fails with a clear error on non-integer min-words" {
+    export MIN_WORDS="two"
+    export PR_BODY="Fixes the login redirect loop on session expiry."
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid min-words"* ]]
+}
+
+@test "does not expand skip-authors globs against the workspace" {
+    export SKIP_AUTHORS="*"
+    export PR_AUTHOR="octocat"
+    export PR_BODY="x"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping automated PR"* ]]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,14 @@ jobs:
         with:
           pr-author: "dependabot[bot]"
           pr-body: "short"
+
+      - name: Test check-pr-description skips automated branches
+        uses: ./.github/actions/check-pr-description
+        with:
+          pr-author: svc-account
+          pr-draft: "false"
+          pr-branch: "dependabot/terraform/aws-5.0"
+          pr-body: "x"
       #endregion
 
       # free-hosted-runner-disk-space action usage and test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,37 @@ jobs:
           command: curl -sSf https://www.hyland.com
           agent-timeout: 1
 
+      #region Test check-pr-description
+      - name: Test check-pr-description happy path
+        uses: ./.github/actions/check-pr-description
+        with:
+          min-words: "5"
+          pr-author: octocat
+          pr-draft: "false"
+          pr-body: "This is a sufficiently long pull request description used to validate the action."
+
+      - name: Test check-pr-description fails on short body
+        id: check-pr-description-short
+        uses: ./.github/actions/check-pr-description
+        continue-on-error: true
+        with:
+          min-words: "15"
+          pr-author: octocat
+          pr-draft: "false"
+          pr-body: "Too short."
+
+      - name: Assert check-pr-description failed on short body
+        if: steps.check-pr-description-short.outcome != 'failure'
+        run: echo "check-pr-description should have failed on a short body!" && exit 1
+
+      - name: Test check-pr-description skips bot authors
+        uses: ./.github/actions/check-pr-description
+        with:
+          min-words: "15"
+          pr-author: "dependabot[bot]"
+          pr-body: "short"
+      #endregion
+
       # free-hosted-runner-disk-space action usage and test
       - name: Check available disk space before running free-hosted-runner-disk-space action
         id: free-hosted-runner-disk-space

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,29 +76,39 @@ jobs:
       - name: Test check-pr-description happy path
         uses: ./.github/actions/check-pr-description
         with:
-          min-words: "5"
           pr-author: octocat
           pr-draft: "false"
-          pr-body: "This is a sufficiently long pull request description used to validate the action."
+          pr-body: "Fixes the login redirect loop on session expiry."
 
       - name: Test check-pr-description fails on short body
         id: check-pr-description-short
         uses: ./.github/actions/check-pr-description
         continue-on-error: true
         with:
-          min-words: "15"
           pr-author: octocat
           pr-draft: "false"
-          pr-body: "Too short."
+          pr-body: "typo fix"
 
       - name: Assert check-pr-description failed on short body
         if: steps.check-pr-description-short.outcome != 'failure'
         run: echo "check-pr-description should have failed on a short body!" && exit 1
 
+      - name: Test check-pr-description fails on ticket-link-only body
+        id: check-pr-description-ticket-only
+        uses: ./.github/actions/check-pr-description
+        continue-on-error: true
+        with:
+          pr-author: octocat
+          pr-draft: "false"
+          pr-body: "https://hyland.atlassian.net/browse/AAE-1234"
+
+      - name: Assert check-pr-description failed on ticket-link-only body
+        if: steps.check-pr-description-ticket-only.outcome != 'failure'
+        run: echo "check-pr-description should have failed on a ticket-link-only body!" && exit 1
+
       - name: Test check-pr-description skips bot authors
         uses: ./.github/actions/check-pr-description
         with:
-          min-words: "15"
           pr-author: "dependabot[bot]"
           pr-body: "short"
       #endregion

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,55 +72,6 @@ jobs:
           command: curl -sSf https://www.hyland.com
           agent-timeout: 1
 
-      #region Test check-pr-description
-      - name: Test check-pr-description happy path
-        uses: ./.github/actions/check-pr-description
-        with:
-          pr-author: octocat
-          pr-draft: "false"
-          pr-body: "Fixes the login redirect loop on session expiry."
-
-      - name: Test check-pr-description fails on short body
-        id: check-pr-description-short
-        uses: ./.github/actions/check-pr-description
-        continue-on-error: true
-        with:
-          pr-author: octocat
-          pr-draft: "false"
-          pr-body: "typo fix"
-
-      - name: Assert check-pr-description failed on short body
-        if: steps.check-pr-description-short.outcome != 'failure'
-        run: echo "check-pr-description should have failed on a short body!" && exit 1
-
-      - name: Test check-pr-description fails on ticket-link-only body
-        id: check-pr-description-ticket-only
-        uses: ./.github/actions/check-pr-description
-        continue-on-error: true
-        with:
-          pr-author: octocat
-          pr-draft: "false"
-          pr-body: "https://hyland.atlassian.net/browse/AAE-1234"
-
-      - name: Assert check-pr-description failed on ticket-link-only body
-        if: steps.check-pr-description-ticket-only.outcome != 'failure'
-        run: echo "check-pr-description should have failed on a ticket-link-only body!" && exit 1
-
-      - name: Test check-pr-description skips bot authors
-        uses: ./.github/actions/check-pr-description
-        with:
-          pr-author: "dependabot[bot]"
-          pr-body: "short"
-
-      - name: Test check-pr-description skips automated branches
-        uses: ./.github/actions/check-pr-description
-        with:
-          pr-author: svc-account
-          pr-draft: "false"
-          pr-branch: "dependabot/terraform/aws-5.0"
-          pr-body: "x"
-      #endregion
-
       # free-hosted-runner-disk-space action usage and test
       - name: Check available disk space before running free-hosted-runner-disk-space action
         id: free-hosted-runner-disk-space

--- a/docs/README.md
+++ b/docs/README.md
@@ -530,6 +530,8 @@ jobs:
 
 The action reads `github.event.pull_request.body`, so the consumer workflow must be triggered by `pull_request` events. No repository checkout is required.
 
+Consumer repositories should pin the reference to a commit SHA rather than a tag, as recommended in [Actions SHA pinning](#actions-sha-pinning) (the `@v18.16.0` above is a placeholder that the release process keeps in sync within this repo). The `min-words` input must be a non-negative integer.
+
 ### configure-git-author
 
 Configures the git username and email to associate commits with the provided identity

--- a/docs/README.md
+++ b/docs/README.md
@@ -506,7 +506,7 @@ Calculate next internal version based on existing tags
 
 ### check-pr-description
 
-Fails a pull request when its description is missing, too short, or only a ticket/URL reference. HTML comments (PR-template boilerplate), URLs and Jira ticket keys (e.g. `AAE-1234`) are excluded before measuring, so pasting just the Jira link does not pass. The remaining "meaningful" text must meet both a character and a word floor. Draft PRs and bot authors are skipped. Add it to a consumer repo via a small `pull_request` workflow.
+Fails a pull request when its description is missing, too short, or only a ticket/URL reference. HTML comments (PR-template boilerplate), URLs and Jira ticket keys (e.g. `AAE-1234`) are excluded before measuring, so pasting just the Jira link does not pass. The remaining "meaningful" text must meet both a character and a word floor. Draft PRs, bot authors (`*[bot]` plus `skip-authors`) and automated branches (`skip-branches`, e.g. `dependabot/*`, `renovate/*`, `updatecli*`, `image-update*`) are skipped. Add it to a consumer repo via a small `pull_request` workflow.
 
 ```yaml
 name: PR Description Check
@@ -527,9 +527,12 @@ jobs:
           min-chars: "15" # optional, default: 15
           min-words: "3" # optional, default: 3
           skip-authors: "dependabot renovate alfresco-build*" # optional
+          skip-branches: "dependabot/* renovate/* updatecli* image-update* flux-*" # optional
 ```
 
 The action reads `github.event.pull_request.body`, so the consumer workflow must be triggered by `pull_request` events. No repository checkout is required.
+
+Automated PRs are skipped two ways: by author (`*[bot]` plus the `skip-authors` globs) and by head branch (`skip-branches` globs, matched against `github.head_ref`). Branch matching also catches automation that runs under a normal service-account login. The `skip-branches` default covers Dependabot, Renovate, updatecli, Flux image-update, release-please, changesets, Snyk, Mend/WhiteSource, propagation (`pr-*`) and generic `automated-*` / `automation/*` branches.
 
 Consumer repositories should pin the reference to a commit SHA rather than a tag, as recommended in [Actions SHA pinning](#actions-sha-pinning) (the `@v18.16.0` above is a placeholder that the release process keeps in sync within this repo). The `min-chars` and `min-words` inputs must be non-negative integers.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -506,7 +506,7 @@ Calculate next internal version based on existing tags
 
 ### check-pr-description
 
-Fails a pull request when its description is missing or shorter than a configurable minimum word count. HTML comments (PR-template boilerplate) are stripped before counting, and draft PRs and bot authors are skipped. Add it to a consumer repo via a small `pull_request` workflow.
+Fails a pull request when its description is missing, too short, or only a ticket/URL reference. HTML comments (PR-template boilerplate), URLs and Jira ticket keys (e.g. `AAE-1234`) are excluded before measuring, so pasting just the Jira link does not pass. The remaining "meaningful" text must meet both a character and a word floor. Draft PRs and bot authors are skipped. Add it to a consumer repo via a small `pull_request` workflow.
 
 ```yaml
 name: PR Description Check
@@ -524,13 +524,14 @@ jobs:
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/check-pr-description@v18.16.0
         with:
-          min-words: "15" # optional, default: 15
+          min-chars: "15" # optional, default: 15
+          min-words: "3" # optional, default: 3
           skip-authors: "dependabot renovate alfresco-build*" # optional
 ```
 
 The action reads `github.event.pull_request.body`, so the consumer workflow must be triggered by `pull_request` events. No repository checkout is required.
 
-Consumer repositories should pin the reference to a commit SHA rather than a tag, as recommended in [Actions SHA pinning](#actions-sha-pinning) (the `@v18.16.0` above is a placeholder that the release process keeps in sync within this repo). The `min-words` input must be a non-negative integer.
+Consumer repositories should pin the reference to a commit SHA rather than a tag, as recommended in [Actions SHA pinning](#actions-sha-pinning) (the `@v18.16.0` above is a placeholder that the release process keeps in sync within this repo). The `min-chars` and `min-words` inputs must be non-negative integers.
 
 ### configure-git-author
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [automate-propagation](#automate-propagation)
   - [awf-run-command](#awf-run-command)
   - [calculate-next-internal-version](#calculate-next-internal-version)
+  - [check-pr-description](#check-pr-description)
   - [configure-git-author](#configure-git-author)
   - [dependabot-missing-actions-check](#dependabot-missing-actions-check)
   - [dbp-charts](#dbp-charts)
@@ -502,6 +503,32 @@ Calculate next internal version based on existing tags
         with:
           next-version: 1.2.3
 ```
+
+### check-pr-description
+
+Fails a pull request when its description is missing or shorter than a configurable minimum word count. HTML comments (PR-template boilerplate) are stripped before counting, and draft PRs and bot authors are skipped. Add it to a consumer repo via a small `pull_request` workflow.
+
+```yaml
+name: PR Description Check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  check-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Alfresco/alfresco-build-tools/.github/actions/check-pr-description@v18.16.0
+        with:
+          min-words: "15" # optional, default: 15
+          skip-authors: "dependabot renovate alfresco-build*" # optional
+```
+
+The action reads `github.event.pull_request.body`, so the consumer workflow must be triggered by `pull_request` events. No repository checkout is required.
 
 ### configure-git-author
 


### PR DESCRIPTION
### Solution

Adds a new composite action `check-pr-description` that fails a pull request when its description is missing, too short, or **only a ticket/URL reference**.

**How it measures.** After stripping PR-template HTML comments, it removes URLs, autolinks, Markdown link targets and Jira ticket keys (e.g. `AAE-1234`), leaving the "meaningful" prose. That prose must satisfy **both**:
- `min-chars` (default `15`) — minimum characters, and
- `min-words` (default `3`) — minimum words (guards against single-token padding like `aaaaaaaaaaaaaaa`).

A body that is empty or only a ticket link/URL fails with a targeted `::error`.

**Automated PRs are skipped two ways** so they never need a description:
- **Author** — `*[bot]` plus a configurable `skip-authors` glob list.
- **Head branch** — a configurable `skip-branches` glob list (matched against `github.head_ref`), which also catches automation running under a normal service-account login. The default covers Dependabot, Renovate, updatecli, Flux image-update, release-please, changesets, Snyk, Mend/WhiteSource, propagation (`pr-*`) and generic `automated-*` / `automation/*` branches.

Draft PRs are skipped too. Both thresholds are validated as non-negative integers, and the `skip-authors`/`skip-branches` loops run with pathname expansion disabled. No repository checkout is required.

This is the **master** for parent [AAE-47024](https://hyland.atlassian.net/browse/AAE-47024); consumer repos reference it via a SHA-pinned `pull_request` workflow. It supersedes the earlier decentralized copy-paste approach (and the out-of-scope `automate-build-tools` pilot, now closed).

### Documentation

`docs/README.md` updated with a `### check-pr-description` section (usage snippet, inputs, author/branch skipping and a SHA-pinning note) plus a TOC entry. `check_readme.sh` passes.

### Tests

`test.yml` exercises the action in the `test` job: happy path, asserted failure on a too-short body, asserted failure on a **ticket-link-only** body, bot-author skip, and **automated-branch skip**. Optional `pr-body`/`pr-author`/`pr-draft`/`pr-branch` inputs make it testable off live PR context. `pre-commit` (including actionlint) passes; all shell logic paths verified locally.

### Ticket

[AAE-47025](https://hyland.atlassian.net/browse/AAE-47025) (parent: [AAE-47024](https://hyland.atlassian.net/browse/AAE-47024))

[AAE-47024]: https://hyland.atlassian.net/browse/AAE-47024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ