### PR TITLE
OPSEXP-4064 docker-dump-containers-logs: capture stderr and skip empty upload

### DIFF
--- a/.github/actions/docker-dump-containers-logs/action.yml
+++ b/.github/actions/docker-dump-containers-logs/action.yml
@@ -9,24 +9,34 @@ runs:
   using: composite
   steps:
     - name: "Dump containers logs and archive them"
+      id: dump
       shell: bash
       run: |
         # Get containers state
         docker ps -a
         # Dump all containers logs to files
         docker ps -a --format '{{.ID}} {{.Names}}' | while read -r id name ; do
-          docker logs "${id}" --tail 5000 > "${name}.log"
+          docker logs "${id}" --tail 5000 > "${name}.log" 2>&1
         done
         # Create archive with log files
-        tar -zcf logs.tar.gz *.log
+        shopt -s nullglob
+        logs=(*.log)
+        if [ ${#logs[@]} -eq 0 ]; then
+          echo "No container logs to archive, skipping upload"
+          echo "has-logs=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "has-logs=true" >> "$GITHUB_OUTPUT"
+        tar -zcf logs.tar.gz "${logs[@]}"
         # Specify output artefact name
         if [ "${{ inputs.output-archive-name }}" = "containers-logs.tar.gz" ]; then
-          echo "artefactName=containers-logs-${{ github.job }}-${{ github.run_attempt }}-$(date +%Y%m%d%H%M%S).tar.gz" >> $GITHUB_ENV
+          echo "artefact-name=containers-logs-${{ github.job }}-${{ github.run_attempt }}-$(date +%Y%m%d%H%M%S).tar.gz" >> "$GITHUB_OUTPUT"
         else
-          echo "artefactName=${{ inputs.output-archive-name }}" >> $GITHUB_ENV
+          echo "artefact-name=${{ inputs.output-archive-name }}" >> "$GITHUB_OUTPUT"
         fi
     - name: "Upload archive containing all *.log files"
+      if: steps.dump.outputs.has-logs == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: logs.tar.gz
-        name: ${{ env.artefactName }}
+        name: ${{ steps.dump.outputs.artefact-name }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -569,8 +569,9 @@ instances that don't yet support `return_run_details`.
 
 ### docker-dump-containers-logs
 
-Dumps Docker containers logs. Each container's log will be stored in a separate `<container_name>.log` file. All files will be archived by default under `containers-logs-<job_id>-<job_retry_number>-<timestamp>.tar.gz` and will be available to download via the workflow's summary page.
+Dumps Docker containers logs. Each container's log (both stdout and stderr) will be stored in a separate `<container_name>.log` file. All files will be archived by default under `containers-logs-<job_id>-<job_retry_number>-<timestamp>.tar.gz` and will be available to download via the workflow's summary page.
 It is also possible to specify the output archive name when providing the `output-archive-name` parameter.
+When no containers are present, no archive is uploaded.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v18.16.0


### PR DESCRIPTION
Improvements to the `docker-dump-containers-logs` composite action.

## Changes

- Redirect each container's **stderr** into its `<name>.log` file (`docker logs ... > file 2>&1`). Previously stderr was left on the step's stderr and leaked into the Actions step output, which is where the "extra output after `docker ps`" was coming from.
- Skip the artifact upload entirely when there are no container logs, instead of failing `tar` on an empty glob (or uploading an empty archive). The dump step now sets a `has-logs` output that gates the upload step.
- Switch the step from writing to `$GITHUB_ENV` to using step outputs (`has-logs`, `artefact-name`).
- Update `docs/README.md` to reflect that both stdout and stderr are captured and that no archive is uploaded when there are no containers.

OPSEXP-4064