### PR TITLE
OPSEXP-4064 Add CLAUDE.md importing copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,10 +159,7 @@ pre-commit run --all-files
 
 ### Pull Request Guidelines
 
-- Use the provided PR template
-- Select appropriate version increment checkbox
-- Provide external PR link for testing
-- Include Jira reference in title when applicable
+- When creating a PR, populate the body from `.github/pull_request_template.md` (`gh pr create` won't auto-apply it): keep the checklist structure, fill the Jira reference, tick the matching `release/*` box, and write the Description.
 
 ## Action Categories and Patterns
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,7 +159,7 @@ pre-commit run --all-files
 
 ### Pull Request Guidelines
 
-- When creating a PR, populate the body from `.github/pull_request_template.md` (`gh pr create` won't auto-apply it): keep the checklist structure, fill the Jira reference, tick the matching `release/*` box, and write the Description.
+- When creating a PR, populate the body from `.github/pull_request_template.md` (`gh pr create` won't auto-apply it): keep the checklist structure, fill the Jira reference, tick the matching Patch/Minor/Major checkbox under "Proposed version increment", and write the Description.
 
 ## Action Categories and Patterns
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v0.47.0
     hooks:
     - id: markdownlint
-      exclude: ^\.github/workflows/.*\.lock\.yml$
+      exclude: ^(\.github/workflows/.*\.lock\.yml|CLAUDE\.md)$
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.github/copilot-instructions.md


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): OPSEXP-4064
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Add a thin `CLAUDE.md` that imports `.github/copilot-instructions.md` via Claude Code's native `@` syntax, so assistant guidance stays in a single source of truth instead of being duplicated.

Also make the PR guidelines in the copilot instructions explicit that when creating a PR the body must be populated from `.github/pull_request_template.md`, since `gh pr create` does not apply the template automatically.

Excludes `CLAUDE.md` from the markdownlint pre-commit hook, since its single `@` import line is not valid markdown and has no user-facing rendering.

OPSEXP-4064