### PR TITLE
[ACS-12078] Simpler maven deploy action

### DIFF
--- a/.github/actions/github-alfresco-deploy/action.yml
+++ b/.github/actions/github-alfresco-deploy/action.yml
@@ -24,15 +24,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: "Set release version"
+    - name: "Set release version to ${{ inputs.release_version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release_version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Deploy release version"
+    - name: "Deploy release version ${{ inputs.release_version }}"
       run: mvn -B -ntp clean deploy -DskipTests -Prelease ${{ inputs.maven_addtional_profiles }} -Dproject.revision.key=${{ github.sha }}
       shell: bash
 
-    - name: "Commit release version"
+    - name: "Commit release version ${{ inputs.release_version }}"
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}
@@ -47,11 +47,11 @@ runs:
         git push origin "${{ inputs.release_version }}"
       shell: bash
 
-    - name: "Set next development version"
+    - name: "Set next development version to ${{ inputs.release_version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development_version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Commit next development version"
+    - name: "Commit next development version ${{ inputs.release_version }}"
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}

--- a/.github/actions/github-alfresco-deploy/action.yml
+++ b/.github/actions/github-alfresco-deploy/action.yml
@@ -1,0 +1,61 @@
+name: Alfresco Deploy
+description: Deploy alfresco project using maven deploy, prepares repository for next development version
+
+inputs:
+  release_version:
+    required: true
+    description: The version of the release (tag).
+  development_version:
+    required: true
+    description: The version that will be set in pom files after the release (next dev version)
+  release_profile:
+    required: false
+    description: Maven profile used for release. Default to "release"
+    default: release
+  maven_addtional_profiles:
+    required: false
+    description: Maven additional profiles used for release. It should start with -P. Ex. "-P additional"
+    default: ''
+  create_tag:
+    required: false
+    description: Boolean if should create tag.
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: "Set release version"
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release_version }}" -DgenerateBackupPoms=false
+      shell: bash
+
+    - name: "Deploy release version"
+      run: mvn -B -ntp clean deploy -DskipTests -Prelease ${{ inputs.maven_addtional_profiles }} -Dproject.revision.key=${{ github.sha }}
+      shell: bash
+
+    - name: "Commit release version"
+      uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        files: |
+          pom.xml
+          */pom.xml
+        message: "[alfresco build][skip ci] Release version ${{ inputs.release_version }}"
+    - name: "Tag release version"
+      if: inputs.create_tag == 'true'
+      run: |
+        git tag "${{ inputs.release_version }}"
+        git push origin "${{ inputs.release_version }}"
+      shell: bash
+
+    - name: "Set next development version"
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development_version }}" -DgenerateBackupPoms=false
+      shell: bash
+
+    - name: "Commit next development version"
+      uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        files: |
+          pom.xml
+          */pom.xml
+        message: "[alfresco build][skip ci] Prepare next development version ${{ inputs.development_version }}"

--- a/.github/actions/github-alfresco-deploy/action.yml
+++ b/.github/actions/github-alfresco-deploy/action.yml
@@ -24,6 +24,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Generate app token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+        private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+        permission-contents: write
+
     - name: "Set release version to ${{ inputs.release_version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release_version }}" -DgenerateBackupPoms=false
       shell: bash

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -44,9 +44,10 @@ runs:
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
         files: |
           pom.xml
-          */pom.xml
+          **/pom.xml
         message: "[alfresco build][skip ci] Release version ${{ inputs.release-version }}"
     - name: "Tag release version"
       if: inputs.create-tag == 'true'
@@ -59,11 +60,12 @@ runs:
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Commit next development version ${{ inputs.release-version }}"
+    - name: "Commit next development version ${{ inputs.development-version }}"
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
         files: |
           pom.xml
-          */pom.xml
+          **/pom.xml
         message: "[alfresco build][skip ci] Prepare next development version ${{ inputs.development-version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -1,4 +1,4 @@
-name: Alfresco Deploy
+name: Release and Deploy Maven project slimmed
 description: Deploy alfresco project using maven deploy, prepares repository for next development version
 
 inputs:

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -2,21 +2,21 @@ name: Release and Deploy Maven project slimmed
 description: Release and Deploy project using maven `deploy`, prepares repository for next development version
 
 inputs:
-  release_version:
+  release-version:
     required: true
     description: The version of the release (tag).
-  development_version:
+  development-version:
     required: true
     description: The version that will be set in pom files after the release (next dev version)
-  release_profile:
+  release-profile:
     required: false
     description: Maven profile used for release. Defaults to "release".
     default: release
-  maven_additional_profiles:
+  maven-additional-profiles:
     required: false
     description: Additional Maven profiles/options for release. Should start with -P (e.g. "-P additional").
     default: ''
-  create_tag:
+  create-tag:
     required: false
     description: Boolean if should create tag.
     default: 'true'
@@ -32,38 +32,38 @@ runs:
         private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
 
-    - name: "Set release version to ${{ inputs.release_version }}"
-      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release_version }}" -DgenerateBackupPoms=false
+    - name: "Set release version to ${{ inputs.release-version }}"
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Deploy release version ${{ inputs.release_version }}"
-      run: mvn -B -ntp clean deploy -DskipTests -P ${{ inputs.release_profile }} ${{ inputs.maven_additional_profiles }} -Dproject.revision.key=${{ github.sha }}
+    - name: "Deploy release version ${{ inputs.release-version }}"
+      run: mvn -B -ntp clean deploy -DskipTests -P ${{ inputs.release-profile }} ${{ inputs.maven-additional-profiles }} -Dproject.revision.key=${{ github.sha }}
       shell: bash
 
-    - name: "Commit release version ${{ inputs.release_version }}"
+    - name: "Commit release version ${{ inputs.release-version }}"
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}
         files: |
           pom.xml
           */pom.xml
-        message: "[alfresco build][skip ci] Release version ${{ inputs.release_version }}"
+        message: "[alfresco build][skip ci] Release version ${{ inputs.release-version }}"
     - name: "Tag release version"
-      if: inputs.create_tag == 'true'
+      if: inputs.create-tag == 'true'
       run: |
-        git tag "${{ inputs.release_version }}"
-        git push origin "${{ inputs.release_version }}"
+        git tag "${{ inputs.release-version }}"
+        git push origin "${{ inputs.release-version }}"
       shell: bash
 
-    - name: "Set next development version to ${{ inputs.release_version }}"
-      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development_version }}" -DgenerateBackupPoms=false
+    - name: "Set next development version to ${{ inputs.release-version }}"
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Commit next development version ${{ inputs.release_version }}"
+    - name: "Commit next development version ${{ inputs.release-version }}"
       uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
       with:
         token: ${{ steps.app-token.outputs.token }}
         files: |
           pom.xml
           */pom.xml
-        message: "[alfresco build][skip ci] Prepare next development version ${{ inputs.development_version }}"
+        message: "[alfresco build][skip ci] Prepare next development version ${{ inputs.development-version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -1,5 +1,5 @@
 name: Release and Deploy Maven project slimmed
-description: Deploy alfresco project using maven deploy, prepares repository for next development version
+description: Release and Deploy project using maven `deploy`, prepares repository for next development version
 
 inputs:
   release_version:

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -1,10 +1,10 @@
-name: Release and Deploy Maven project slimmed
-description: Release and Deploy project using maven `deploy`, prepares repository for next development version
+name: Maven Release (Slim)
+description: Sets the release version, deploys artifacts with Maven, optionally tags the release, then sets the next development version.
 
 inputs:
   token:
     required: true
-    description: Github token required for authentication.
+    description: GitHub token required for authentication.
   release-version:
     required: true
     description: The version of the release (tag).

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -2,6 +2,9 @@ name: Release and Deploy Maven project slimmed
 description: Release and Deploy project using maven `deploy`, prepares repository for next development version
 
 inputs:
+  token:
+    required: true
+    description: Github token required for authentication.
   release-version:
     required: true
     description: The version of the release (tag).
@@ -12,43 +15,39 @@ inputs:
     required: false
     description: Maven profile used for release. Defaults to "release".
     default: release
-  maven-additional-profiles:
+  maven-args:
     required: false
-    description: Additional Maven profiles/options for release. Should start with -P (e.g. "-P additional").
-    default: ''
+    description: Additional Maven arguments for release. Defaults to "-DskipTests".
+    default: -DskipTests
   create-tag:
     required: false
     description: Boolean if should create tag.
     default: 'true'
+  commit-message-prefix:
+    required: false
+    description: Prefix used by bot for commit message. Defaults to "[skip ci]".
+    default: '[skip ci]'
 
 runs:
   using: composite
   steps:
-    - name: Generate app token
-      id: app-token
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-      with:
-        client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
-        private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
-        permission-contents: write
-
     - name: "Set release version to ${{ inputs.release-version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false
       shell: bash
 
     - name: "Deploy release version ${{ inputs.release-version }}"
-      run: mvn -B -ntp clean deploy -DskipTests -P ${{ inputs.release-profile }} ${{ inputs.maven-additional-profiles }} -Dproject.revision.key=${{ github.sha }}
+      run: mvn -B -ntp clean deploy -P ${{ inputs.release-profile }} -Dproject.revision.key=${{ github.sha }} ${{ inputs.maven-args }}
       shell: bash
 
     - name: "Commit release version ${{ inputs.release-version }}"
       uses: iarekylew00t/verified-bot-commit@33985d44b7719dcaf0b854a0f4b0caad9bdc5b86 # v2.3.3
       with:
-        token: ${{ steps.app-token.outputs.token }}
+        token: ${{ inputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
         files: |
           pom.xml
           **/pom.xml
-        message: "[alfresco build][skip ci] Release version ${{ inputs.release-version }}"
+        message: "${{ inputs.commit-message-prefix }} Release version ${{ inputs.release-version }}"
     - name: "Tag release version"
       if: inputs.create-tag == 'true'
       run: |
@@ -63,9 +62,9 @@ runs:
     - name: "Commit next development version ${{ inputs.development-version }}"
       uses: iarekylew00t/verified-bot-commit@33985d44b7719dcaf0b854a0f4b0caad9bdc5b86 # v2.3.3
       with:
-        token: ${{ steps.app-token.outputs.token }}
+        token: ${{ inputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
         files: |
           pom.xml
           **/pom.xml
-        message: "[alfresco build][skip ci] Prepare next development version ${{ inputs.development-version }}"
+        message: "${{ inputs.commit-message-prefix }} Prepare next development version ${{ inputs.development-version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -10,11 +10,11 @@ inputs:
     description: The version that will be set in pom files after the release (next dev version)
   release_profile:
     required: false
-    description: Maven profile used for release. Default to "release"
+    description: Maven profile used for release. Defaults to "release".
     default: release
-  maven_addtional_profiles:
+  maven_additional_profiles:
     required: false
-    description: Maven additional profiles used for release. It should start with -P. Ex. "-P additional"
+    description: Additional Maven profiles/options for release. Should start with -P (e.g. "-P additional").
     default: ''
   create_tag:
     required: false
@@ -37,7 +37,7 @@ runs:
       shell: bash
 
     - name: "Deploy release version ${{ inputs.release_version }}"
-      run: mvn -B -ntp clean deploy -DskipTests -Prelease ${{ inputs.maven_addtional_profiles }} -Dproject.revision.key=${{ github.sha }}
+      run: mvn -B -ntp clean deploy -DskipTests -P ${{ inputs.release_profile }} ${{ inputs.maven_additional_profiles }} -Dproject.revision.key=${{ github.sha }}
       shell: bash
 
     - name: "Commit release version ${{ inputs.release_version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
 
     - name: "Commit release version ${{ inputs.release-version }}"
-      uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
+      uses: iarekylew00t/verified-bot-commit@33985d44b7719dcaf0b854a0f4b0caad9bdc5b86 # v2.3.3
       with:
         token: ${{ steps.app-token.outputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -61,7 +61,7 @@ runs:
       shell: bash
 
     - name: "Commit next development version ${{ inputs.development-version }}"
-      uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
+      uses: iarekylew00t/verified-bot-commit@33985d44b7719dcaf0b854a0f4b0caad9bdc5b86 # v2.3.3
       with:
         token: ${{ steps.app-token.outputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -56,7 +56,7 @@ runs:
         git push origin "${{ inputs.release-version }}"
       shell: bash
 
-    - name: "Set next development version to ${{ inputs.release-version }}"
+    - name: "Set next development version to ${{ inputs.development-version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
       shell: bash
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1923,8 +1923,8 @@ A lightweight Maven release action that sets the release version, deploys the ar
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
 ```
 
-Java and Maven should be set up before invoking the action. The provided `token` is used to push the release/development version commits and must have write access to the repository contents.
-Checkout step with enough permission should be performed before using this action.
+Java and Maven should be set up before invoking the action. The provided `token` must have write access to the repository contents to push the release/development version commits and (if enabled) the release tag.
+Ensure your checkout step configures Git credentials with sufficient permissions before using this action.
 
 ### maven-tag
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1909,20 +1909,22 @@ Used to release Activiti projects. Update versions in POM files, create git tags
 
 ### maven-release-slim
 
-A lightweight Maven release action that sets the release version, deploys the artifacts using Maven `deploy`, tags the release and prepares the repository for the next development version. Uses a GitHub App for authenticated commits and assumes the deploy configuration is already present in the project's POM files.
+A lightweight Maven release action that sets the release version, deploys the artifacts using Maven `deploy`, tags the release and prepares the repository for the next development version. Uses `verified-bot-commit` for signed commits and assumes the deploy configuration is already present in the project's POM files.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.17.1
         with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           release-version: 1.2.3
           development-version: 1.2.4-SNAPSHOT
           release-profile: release  # optional, default: release
-          maven-additional-profiles: '-P additional'  # optional, default: ''
+          maven-args: -DskipTests  # optional, default: -DskipTests
           create-tag: 'true'  # optional, default: 'true'
+          commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
 ```
 
-Requires the `GH_APP_ENGINEERING_CONTRIB_CLIENT_ID` variable and the `GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY` secret to be available for GitHub App authentication. Java and Maven should be set up before invoking the action.
-
+Java and Maven should be set up before invoking the action. The provided `token` is used to push the release/development version commits and must have write access to the repository contents.
+Checkout step with enough permission should be performed before using this action. 
 ### maven-tag
 
 Updates POM files to the next pre-release, commits changes and creates a Git tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1914,11 +1914,11 @@ A lightweight Maven release action that sets the release version, deploys the ar
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.17.1
         with:
-          release_version: 1.2.3
-          development_version: 1.2.4-SNAPSHOT
-          release_profile: release  # optional, default: release
-          maven_additional_profiles: '-P additional'  # optional, default: ''
-          create_tag: 'true'  # optional, default: 'true'
+          release-version: 1.2.3
+          development-version: 1.2.4-SNAPSHOT
+          release-profile: release  # optional, default: release
+          maven-additional-profiles: '-P additional'  # optional, default: ''
+          create-tag: 'true'  # optional, default: 'true'
 ```
 
 Requires the `GH_APP_ENGINEERING_CONTRIB_CLIENT_ID` variable and the `GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY` secret to be available for GitHub App authentication. Java and Maven should be set up before invoking the action.

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [maven-build-and-tag](#maven-build-and-tag)
   - [maven-deploy-file](#maven-deploy-file)
   - [maven-release](#maven-release)
+  - [maven-release-slim](#maven-release-slim)
   - [maven-tag](#maven-tag)
   - [maven-update-pom-version](#maven-update-pom-version)
   - [md-toc](#md-toc)
@@ -1905,6 +1906,22 @@ Used to release Activiti projects. Update versions in POM files, create git tags
           nexus-username: "${{ secrets.NEXUS_USERNAME }}"
           nexus-password: "${{ secrets.NEXUS_PASSWORD }}"
 ```
+
+### maven-release-slim
+
+A lightweight Maven release action that sets the release version, deploys the artifacts using Maven `deploy`, tags the release and prepares the repository for the next development version. Uses a GitHub App for authenticated commits and assumes the deploy configuration is already present in the project's POM files.
+
+```yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.17.1
+        with:
+          release_version: 1.2.3
+          development_version: 1.2.4-SNAPSHOT
+          release_profile: release  # optional, default: release
+          maven_additional_profiles: '-P additional'  # optional, default: ''
+          create_tag: 'true'  # optional, default: 'true'
+```
+
+Requires the `GH_APP_ENGINEERING_CONTRIB_CLIENT_ID` variable and the `GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY` secret to be available for GitHub App authentication. Java and Maven should be set up before invoking the action.
 
 ### maven-tag
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1925,6 +1925,7 @@ A lightweight Maven release action that sets the release version, deploys the ar
 
 Java and Maven should be set up before invoking the action. The provided `token` is used to push the release/development version commits and must have write access to the repository contents.
 Checkout step with enough permission should be performed before using this action.
+
 ### maven-tag
 
 Updates POM files to the next pre-release, commits changes and creates a Git tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1924,7 +1924,7 @@ A lightweight Maven release action that sets the release version, deploys the ar
 ```
 
 Java and Maven should be set up before invoking the action. The provided `token` is used to push the release/development version commits and must have write access to the repository contents.
-Checkout step with enough permission should be performed before using this action. 
+Checkout step with enough permission should be performed before using this action.
 ### maven-tag
 
 Updates POM files to the next pre-release, commits changes and creates a Git tag.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): https://hyland.atlassian.net/browse/ACS-12078
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:
- https://github.com/Alfresco/alfresco-audit-storage/actions/runs/29019697823/job/86123335157

### Description

Adding new action that is going to replace maven-release-plugin for Alfresco (and others!) maven projects.
Why?
Because maven-release-plugin is struggling with creation of signed commits and branch protections.
