### PR TITLE
OPSEXP-4107 support custom card actions and body

### DIFF
--- a/.github/actions/send-teams-notification/action.yml
+++ b/.github/actions/send-teams-notification/action.yml
@@ -221,7 +221,7 @@ runs:
         COLOR: ${{ steps.compute-color.outputs.result }}
         TITLE: "Notification on ${{ steps.compute-event.outputs.result }} on branch [`${{ steps.get-branch-name.outputs.branch-name }}`](${{ env.REPO_URL }}/tree/${{ steps.get-branch-name.outputs.branch-name }})"
         ENTITIES: ${{ steps.transform-mentions.outputs.result }}
-        ACTIONS: ${{ inputs.card-actions }}
+        ACTIONS: ${{ inputs.card-actions || '[]' }}
         EXTRA_BODY: ${{ steps.compute-extra-body.outputs.result }}
       with:
         webhook_url: ${{ inputs.webhook-url }}

--- a/.github/actions/send-teams-notification/action.yml
+++ b/.github/actions/send-teams-notification/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Comma-separated list of Teams tags to mention in format "tag name|tag id" (e.g.: "Security Champions|base64IdIncluding==")'
     required: false
     default: ''
+  card-actions:
+    description: 'JSON array of Adaptive Card actions (e.g. Action.OpenUrl buttons) appended to the card'
+    required: false
+    default: '[]'
+  card-extra-body:
+    description: 'JSON array of Adaptive Card body elements (e.g. a FactSet or monospace log block) appended after the message'
+    required: false
+    default: '[]'
   skip_checkout:
     description: If the internal checkout action should be skipped or not
     required: false
@@ -192,6 +200,14 @@ runs:
           echo "actor_avatar_url=$AVATARS_URL/$TRIGGERING_ACTOR?s=32" >> $GITHUB_OUTPUT
         fi
 
+    - name: Compute extra body
+      id: compute-extra-body
+      shell: bash
+      env:
+        EXTRA_BODY: ${{ inputs.card-extra-body }}
+      run: |
+        ${{ github.action_path }}/compute-extra-body.sh >> $GITHUB_OUTPUT
+
     - name: Send teams notification
       uses: skitionek/notify-microsoft-teams@0953822ab410e9a50e2abd2d6d8f85230b1ae4d6 # v1.1.0
       env:
@@ -205,6 +221,8 @@ runs:
         COLOR: ${{ steps.compute-color.outputs.result }}
         TITLE: "Notification on ${{ steps.compute-event.outputs.result }} on branch [`${{ steps.get-branch-name.outputs.branch-name }}`](${{ env.REPO_URL }}/tree/${{ steps.get-branch-name.outputs.branch-name }})"
         ENTITIES: ${{ steps.transform-mentions.outputs.result }}
+        ACTIONS: ${{ inputs.card-actions }}
+        EXTRA_BODY: ${{ steps.compute-extra-body.outputs.result }}
       with:
         webhook_url: ${{ inputs.webhook-url }}
         job: "{}"
@@ -318,8 +336,9 @@ runs:
                           ]
                         }
                       ]
-                    }
+                    }${{ env.EXTRA_BODY }}
                   ],
+                  "actions": ${{ env.ACTIONS }},
                   "backgroundImage": {
                     "url": "https://singlecolorimage.com/get/${{ env.COLOR }}/2x2",
                     "fillMode": "RepeatHorizontally"

--- a/.github/actions/send-teams-notification/action.yml
+++ b/.github/actions/send-teams-notification/action.yml
@@ -209,27 +209,11 @@ runs:
         ${{ github.action_path }}/compute-extra-body.sh >> $GITHUB_OUTPUT
 
     - name: Send teams notification
-      uses: skitionek/notify-microsoft-teams@0953822ab410e9a50e2abd2d6d8f85230b1ae4d6 # v1.1.0
+      shell: bash
       env:
-        ACTOR_URL: ${{ steps.compute-actor-urls.outputs.actor_url }}
-        ACTOR_AVATAR_URL: ${{ steps.compute-actor-urls.outputs.actor_avatar_url }}
-        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        SMALL_SHA: ${{ steps.compute-small-sha.outputs.result }}
-        MESSAGE_OUTPUT: ${{ steps.compute-message.outputs.result }}
-        RUN_LINK: ${{ steps.compute-run-link.outputs.result }}
-        WORKFLOW_TITLE: ${{ steps.compute-workflow-title.outputs.result }}
-        COLOR: ${{ steps.compute-color.outputs.result }}
-        TITLE: "Notification on ${{ steps.compute-event.outputs.result }} on branch [`${{ steps.get-branch-name.outputs.branch-name }}`](${{ env.REPO_URL }}/tree/${{ steps.get-branch-name.outputs.branch-name }})"
-        ENTITIES: ${{ steps.transform-mentions.outputs.result }}
-        ACTIONS: ${{ inputs.card-actions || '[]' }}
-        EXTRA_BODY: ${{ steps.compute-extra-body.outputs.result }}
-      with:
-        webhook_url: ${{ inputs.webhook-url }}
-        job: "{}"
-        steps: "{}"
-        needs: "{}"
-        dry_run: ${{ inputs.dry-run }}
-        raw: >-
+        WEBHOOK_URL: ${{ inputs.webhook-url }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        PAYLOAD: >-
           {
             "type": "message",
             "attachments": [
@@ -242,7 +226,7 @@ runs:
                       "type": "TextBlock",
                       "size": "medium",
                       "weight": "bolder",
-                      "text": "${{ inputs.title || env.TITLE }}",
+                      "text": "${{ inputs.title || format('Notification on {0} on branch [`{1}`]({2}/{3}/tree/{4})', steps.compute-event.outputs.result, steps.get-branch-name.outputs.branch-name, github.server_url, github.repository, steps.get-branch-name.outputs.branch-name) }}",
                       "style": "heading",
                       "wrap": true
                     },
@@ -255,7 +239,7 @@ runs:
                             {
                               "type": "Image",
                               "style": "person",
-                              "url": "${{ env.ACTOR_AVATAR_URL }}",
+                              "url": "${{ steps.compute-actor-urls.outputs.actor_avatar_url }}",
                               "altText": "${{ github.triggering_actor }}",
                               "size": "small"
                             }
@@ -267,7 +251,7 @@ runs:
                           "items": [
                             {
                               "type": "TextBlock",
-                              "text": "[${{ github.triggering_actor }}](${{ env.ACTOR_URL }})"
+                              "text": "[${{ github.triggering_actor }}](${{ steps.compute-actor-urls.outputs.actor_url }})"
                             }
                           ]
                         },
@@ -289,7 +273,7 @@ runs:
                           "items": [
                             {
                               "type": "TextBlock",
-                              "text": "[${{ github.repository }}](${{ env.REPO_URL }})"
+                              "text": "[${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})"
                             }
                           ]
                         }
@@ -303,7 +287,7 @@ runs:
                           "items": [
                             {
                               "type": "TextBlock",
-                              "text": "**Action**: [${{ env.WORKFLOW_TITLE }}](${{ env.RUN_LINK }})"
+                              "text": "**Action**: [${{ steps.compute-workflow-title.outputs.result }}](${{ steps.compute-run-link.outputs.result }})"
                             }
                           ]
                         },
@@ -312,7 +296,7 @@ runs:
                           "items": [
                             {
                               "type": "TextBlock",
-                              "text": "**Commit**: [`${{ env.SMALL_SHA }}`](${{ env.REPO_URL }}/commit/${{ github.sha }})"
+                              "text": "**Commit**: [`${{ steps.compute-small-sha.outputs.result }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                           ]
                         }
@@ -330,26 +314,58 @@ runs:
                             },
                             {
                               "type": "TextBlock",
-                              "text": "${{ env.MESSAGE_OUTPUT }} ",
+                              "text": "${{ steps.compute-message.outputs.result }} ",
                               "wrap": true
                             }
                           ]
                         }
                       ]
-                    }${{ env.EXTRA_BODY }}
+                    }${{ steps.compute-extra-body.outputs.result }}
                   ],
-                  "actions": ${{ env.ACTIONS }},
+                  "actions": ${{ inputs.card-actions || '[]' }},
                   "backgroundImage": {
-                    "url": "https://singlecolorimage.com/get/${{ env.COLOR }}/2x2",
+                    "url": "https://singlecolorimage.com/get/${{ steps.compute-color.outputs.result }}/2x2",
                     "fillMode": "RepeatHorizontally"
                   },
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   "version": "1.5",
                   "msteams": {
                     "width": "full",
-                    "entities": ${{ env.ENTITIES }}
+                    "entities": ${{ steps.transform-mentions.outputs.result }}
                   }
                 }
               }
             ]
           }
+      run: |
+        set -euo pipefail
+
+        if ! jq -e . >/dev/null 2>&1 <<<"${PAYLOAD}"; then
+          echo "::error::Computed Teams payload is not valid JSON"
+          echo "${PAYLOAD}"
+          exit 1
+        fi
+
+        if [ -n "${DRY_RUN}" ] && [ "${DRY_RUN}" != "false" ]; then
+          echo "Dry run - skipping notification send. Payload:"
+          jq . <<<"${PAYLOAD}"
+          exit 0
+        fi
+
+        response_file="$(mktemp)"
+        http_code="$(curl -sS -o "${response_file}" -w '%{http_code}' \
+          -X POST -H 'Content-Type: application/json' \
+          --data-raw "${PAYLOAD}" "${WEBHOOK_URL}")"
+
+        echo "Response status: ${http_code}"
+        cat "${response_file}" && echo
+
+        case "${http_code}" in
+          200 | 202)
+            echo "Notification sent to Microsoft Teams"
+            ;;
+          *)
+            echo "::error::Failed to send notification to Microsoft Teams (HTTP ${http_code})"
+            exit 1
+            ;;
+        esac

--- a/.github/actions/send-teams-notification/compute-extra-body.sh
+++ b/.github/actions/send-teams-notification/compute-extra-body.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTRA_BODY="${EXTRA_BODY:-[]}"
+
+if [ "$(jq 'length' <<<"$EXTRA_BODY")" -eq 0 ]; then
+    echo "result="
+else
+    echo "result=,$(jq -c '.[]' <<<"$EXTRA_BODY" | paste -sd, -)"
+fi

--- a/.github/actions/send-teams-notification/compute-extra-body.sh
+++ b/.github/actions/send-teams-notification/compute-extra-body.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 EXTRA_BODY="${EXTRA_BODY:-[]}"
 
+if [ "$(jq -r 'type' <<<"$EXTRA_BODY" 2>/dev/null)" != "array" ]; then
+    echo "card-extra-body must be a JSON array (e.g. '[{\"type\":\"TextBlock\",\"text\":\"hi\"}]'), got: ${EXTRA_BODY}" >&2
+    exit 1
+fi
+
 if [ "$(jq 'length' <<<"$EXTRA_BODY")" -eq 0 ]; then
     echo "result="
 else

--- a/.github/actions/send-teams-notification/tests/send-teams-notification.bats
+++ b/.github/actions/send-teams-notification/tests/send-teams-notification.bats
@@ -347,3 +347,41 @@ BATS
     [ "$status" -eq 1 ]
     [ "$output" = "Error: Input 'John Doe' does not contain the expected format with a '|' separator" ]
 }
+
+# compute-extra-body.sh tests
+
+@test "compute-extra-body with default empty array" {
+    export EXTRA_BODY="[]"
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "result=" ]
+}
+
+@test "compute-extra-body unset defaults to empty" {
+    unset EXTRA_BODY
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "result=" ]
+}
+
+@test "compute-extra-body with single element" {
+    export EXTRA_BODY='[{"type":"FactSet","facts":[{"title":"Cluster","value":"my-env"}]}]'
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'result=,{"type":"FactSet","facts":[{"title":"Cluster","value":"my-env"}]}' ]
+}
+
+@test "compute-extra-body with multiple elements" {
+    export EXTRA_BODY='[{"type":"TextBlock","text":"one"},{"type":"TextBlock","text":"two"}]'
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'result=,{"type":"TextBlock","text":"one"},{"type":"TextBlock","text":"two"}' ]
+}

--- a/.github/actions/send-teams-notification/tests/send-teams-notification.bats
+++ b/.github/actions/send-teams-notification/tests/send-teams-notification.bats
@@ -385,3 +385,30 @@ BATS
     [ "$status" -eq 0 ]
     [ "$output" = 'result=,{"type":"TextBlock","text":"one"},{"type":"TextBlock","text":"two"}' ]
 }
+
+@test "compute-extra-body rejects a JSON object" {
+    export EXTRA_BODY='{"type":"TextBlock"}'
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be a JSON array"* ]]
+}
+
+@test "compute-extra-body rejects a JSON string" {
+    export EXTRA_BODY='"foo"'
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be a JSON array"* ]]
+}
+
+@test "compute-extra-body rejects invalid JSON" {
+    export EXTRA_BODY='not json'
+
+    run compute-extra-body.sh
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be a JSON array"* ]]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2330,6 +2330,29 @@ To get the necessary data for mentions:
 
 ![PowerAutomate Get Tag IDs Flow](./images/send-teams-get-tag-id.png)
 
+#### Custom card content
+
+Beyond the standard card, callers can extend it with their own Adaptive Card content via two optional inputs (both default to an empty array, so existing usages are unaffected):
+
+- `card-actions`: JSON array of [Adaptive Card actions](https://adaptivecards.io/explorer/Action.OpenUrl.html) rendered as buttons at the bottom of the card
+- `card-extra-body`: JSON array of Adaptive Card body elements (e.g. a `FactSet` or a monospace `TextBlock`) appended after the message
+
+Sample usage with custom buttons and body elements:
+
+```yml
+      uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@v18.18.0
+      with:
+        webhook-url: ${{ secrets.MSTEAMS_WEBHOOK }}
+        title: "⛩️ Performance test failed"
+        status: failure
+        card-actions: >-
+          [{"type":"Action.OpenUrl","title":"Create Jira bug","url":"https://jira.example.com/create"},
+           {"type":"Action.OpenUrl","title":"View pipeline run","url":"${{ env.BUILD_WEB_URL }}"}]
+        card-extra-body: >-
+          [{"type":"FactSet","facts":[{"title":"Cluster","value":"my-env"}]},
+           {"type":"TextBlock","fontType":"Monospace","wrap":true,"text":"...log tail..."}]
+```
+
 ### setup-checkov
 
 Set up a specific version of Checkov and add it to the PATH.


### PR DESCRIPTION
Add optional card-actions and card-extra-body inputs so callers can append Adaptive Card action buttons (e.g. Action.OpenUrl) and extra body elements (FactSet, monospace log blocks) to the notification card. Both default to an empty array, so existing usages render unchanged.

<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4107
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-alfresco-pipeline/pull/1951

### Description

<!-- Explain your changes -->
