### PR TITLE
OPSEXP-4225 fix(env-load-from-yaml): support multiline env variable values

### DIFF
--- a/.github/actions/env-load-from-yaml/action.yml
+++ b/.github/actions/env-load-from-yaml/action.yml
@@ -12,13 +12,8 @@ runs:
   using: "composite"
   steps:
     - name: Parse env global
-      run: |
-        while read ENVVAR; do
-          if [[ "$ENVVAR" =~ ${{ inputs.ignore_regex }} ]]; then
-            echo "Skipping unwanted $ENVVAR"
-            continue
-          fi
-          eval $ENVVAR
-          echo "$(eval echo $ENVVAR)" >> $GITHUB_ENV
-        done < <(yq '.env.global[]' ${{ inputs.yml_path }})
       shell: bash
+      env:
+        IGNORE_REGEX: ${{ inputs.ignore_regex }}
+        YML_PATH: ${{ inputs.yml_path }}
+      run: ${{ github.action_path }}/env-load-from-yaml.sh

--- a/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
+++ b/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+while IFS= read -r ENVVAR; do
+  if [[ "$ENVVAR" =~ $IGNORE_REGEX ]]; then
+    echo "Skipping unwanted $ENVVAR"
+    continue
+  fi
+  name="${ENVVAR%%=*}"
+  rhs="${ENVVAR#*=}"
+  eval "value=\"$rhs\""
+  # shellcheck disable=SC2154 # value is assigned above via eval
+  export "$name=$value"
+  if [[ "$value" == *$'\n'* ]]; then
+    delimiter="EOF_$(openssl rand -hex 8)"
+    {
+      printf '%s<<%s\n' "$name" "$delimiter"
+      printf '%s\n' "$value"
+      printf '%s\n' "$delimiter"
+    } >> "$GITHUB_ENV"
+  else
+    printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+  fi
+done < <(yq '.env.global[]' "$YML_PATH")

--- a/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
+++ b/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-set -e
+set -eo pipefail
+
+# Capture yq output before looping so a yq failure/missing file aborts the
+# script instead of being swallowed by process substitution.
+entries="$(yq '.env.global[]' "$YML_PATH")"
 
 while IFS= read -r ENVVAR; do
+  [ -z "$ENVVAR" ] && continue
   if [[ "$ENVVAR" =~ $IGNORE_REGEX ]]; then
     echo "Skipping unwanted $ENVVAR"
     continue
@@ -21,4 +26,4 @@ while IFS= read -r ENVVAR; do
   else
     printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
   fi
-done < <(yq '.env.global[]' "$YML_PATH")
+done <<< "$entries"

--- a/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
+++ b/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
@@ -1,0 +1,55 @@
+setup() {
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    PATH="$DIR/..:$PATH"
+
+    export GITHUB_ENV="$BATS_TEST_TMPDIR/github_env"
+    : > "$GITHUB_ENV"
+    export IGNORE_REGEX='^$'
+}
+
+@test "simple value is written" {
+    export YML_PATH="$DIR/simple.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qx 'APP_SETTING_ONE=value' "$GITHUB_ENV"
+}
+
+@test "ignore_regex skips matching lines" {
+    export YML_PATH="$DIR/simple.yml"
+    export IGNORE_REGEX='^TRAVIS_BRANCH=.*'
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qx 'APP_SETTING_ONE=value' "$GITHUB_ENV"
+    ! grep -q '^TRAVIS_BRANCH=' "$GITHUB_ENV"
+}
+
+@test "single-line variable reference is expanded" {
+    export YML_PATH="$DIR/expansion.yml"
+    export ANOTHER_VAR="expanded-value"
+    export SOURCE_MULTILINE="ignored-here"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qx 'VAR2=expanded-value' "$GITHUB_ENV"
+}
+
+@test "multiline value uses heredoc and round-trips" {
+    export YML_PATH="$DIR/expansion.yml"
+    export ANOTHER_VAR="whatever"
+    export SOURCE_MULTILINE=$'-----BEGIN RSA PRIVATE KEY-----\nline one\nline two\n-----END RSA PRIVATE KEY-----'
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+
+    grep -q '^PEM<<EOF_' "$GITHUB_ENV"
+    grep -qx -- '-----BEGIN RSA PRIVATE KEY-----' "$GITHUB_ENV"
+    grep -qx -- '-----END RSA PRIVATE KEY-----' "$GITHUB_ENV"
+
+    # the value between the heredoc delimiters must round-trip in full,
+    # parsing the file the way GitHub Actions consumes $GITHUB_ENV
+    delimiter="$(sed -n 's/^PEM<<//p' "$GITHUB_ENV")"
+    extracted="$(awk -v d="$delimiter" '
+        $0 == "PEM<<" d { capture = 1; next }
+        capture && $0 == d { capture = 0; next }
+        capture { print }
+    ' "$GITHUB_ENV")"
+    [ "$extracted" = "$SOURCE_MULTILINE" ]
+}

--- a/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
+++ b/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
@@ -32,6 +32,13 @@ setup() {
     grep -qx 'VAR2=expanded-value' "$GITHUB_ENV"
 }
 
+@test "missing yaml file aborts with non-zero and writes nothing" {
+    export YML_PATH="$DIR/does-not-exist.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -ne 0 ]
+    [ ! -s "$GITHUB_ENV" ]
+}
+
 @test "multiline value uses heredoc and round-trips" {
     export YML_PATH="$DIR/expansion.yml"
     export ANOTHER_VAR="whatever"

--- a/.github/actions/env-load-from-yaml/tests/expansion.yml
+++ b/.github/actions/env-load-from-yaml/tests/expansion.yml
@@ -1,0 +1,4 @@
+env:
+  global:
+    - VAR2=$ANOTHER_VAR
+    - PEM=$SOURCE_MULTILINE

--- a/.github/actions/env-load-from-yaml/tests/simple.yml
+++ b/.github/actions/env-load-from-yaml/tests/simple.yml
@@ -1,0 +1,4 @@
+env:
+  global:
+    - TRAVIS_BRANCH=whatever
+    - APP_SETTING_ONE=value

--- a/.github/tests/env-load-from-yaml/env.yml
+++ b/.github/tests/env-load-from-yaml/env.yml
@@ -2,3 +2,4 @@ env:
   global:
     - TRAVIS_BRANCH=whatever
     - APP_SETTING_ONE=value
+    - PEM=$SOURCE_MULTILINE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,12 @@ jobs:
       - uses: ./.github/actions/setup-terraform-docs
       - uses: ./.github/actions/setup-kcadm
       - uses: ./.github/actions/env-load-from-yaml
+        env:
+          SOURCE_MULTILINE: |
+            -----BEGIN RSA PRIVATE KEY-----
+            line one
+            line two
+            -----END RSA PRIVATE KEY-----
         with:
           ignore_regex: ^TRAVIS_BRANCH=.*
           yml_path: ./.github/tests/env-load-from-yaml/env.yml
@@ -177,6 +183,18 @@ jobs:
           fi
           if [ -n "$TRAVIS_BRANCH" ]; then
             echo TRAVIS_BRANCH should not be set!
+            exit 1
+          fi
+          if [[ "$PEM" != *$'\n'* ]]; then
+            echo PEM should be multiline!
+            exit 1
+          fi
+          if [[ "$PEM" != *"-----BEGIN RSA PRIVATE KEY-----"* ]]; then
+            echo PEM should contain the BEGIN line!
+            exit 1
+          fi
+          if [[ "$PEM" != *"-----END RSA PRIVATE KEY-----"* ]]; then
+            echo PEM should contain the END line!
             exit 1
           fi
 


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): OPSEXP-4225
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

The `env-load-from-yaml` action mangled multiline env variable values. When an `env.global[]` entry referenced a multiline value — e.g. `TF_VAR_github_app_pem_file=$CUSTOM_SECRET_0` where `CUSTOM_SECRET_0` holds a PEM private key — the unquoted `eval` word-split the expanded value (only the first token survived, the rest ran as shell commands) and `$GITHUB_ENV` was written as `KEY=value` instead of the heredoc-delimiter format GitHub requires for multiline values, corrupting the env file.

This extracts the logic into `env-load-from-yaml.sh`, expands values with quoting to preserve newlines and spaces, and emits multiline values using the `NAME<<DELIM … DELIM` heredoc format. Single-line assignments, `${VAR}` references, and `ignore_regex` behaviour are unchanged. Added bats coverage (simple value, `ignore_regex`, single-var expansion, and a multiline round-trip) following the repo's script + bats convention.

OPSEXP-4225