### PR TITLE
ACS-12079 Add maven-compute-release-versions composite action

### DIFF
--- a/.github/actions/maven-compute-release-versions/action.yml
+++ b/.github/actions/maven-compute-release-versions/action.yml
@@ -1,7 +1,7 @@
 name: Maven Compute Release Versions
 description: >
-  Derives the release version and next development version from the current POM SNAPSHOT version.
-  Strips the -SNAPSHOT suffix to produce the release version, then increments the patch segment
+  Derives the release version and next development version from the current POM version (typically a -SNAPSHOT version).
+  Strips a trailing -SNAPSHOT suffix to produce the release version, then increments the last numeric segment
   for the next development version. Maven must be available on PATH before invoking this action.
 
 outputs:

--- a/.github/actions/maven-compute-release-versions/action.yml
+++ b/.github/actions/maven-compute-release-versions/action.yml
@@ -1,0 +1,20 @@
+name: Maven Compute Release Versions
+description: >
+  Derives the release version and next development version from the current POM SNAPSHOT version.
+  Strips the -SNAPSHOT suffix to produce the release version, then increments the patch segment
+  for the next development version. Maven must be available on PATH before invoking this action.
+
+outputs:
+  release-version:
+    description: "The release version, e.g. 26.2.0"
+    value: ${{ steps.compute.outputs.release-version }}
+  development-version:
+    description: "The next development version, e.g. 26.2.1-SNAPSHOT"
+    value: ${{ steps.compute.outputs.development-version }}
+
+runs:
+  using: composite
+  steps:
+    - id: compute
+      shell: bash
+      run: ${{ github.action_path }}/compute-versions.sh

--- a/.github/actions/maven-compute-release-versions/action.yml
+++ b/.github/actions/maven-compute-release-versions/action.yml
@@ -8,9 +8,9 @@ outputs:
   release-version:
     description: "The release version, e.g. 26.2.0"
     value: ${{ steps.compute.outputs.release-version }}
-  development-version:
+  next-development-version:
     description: "The next development version, e.g. 26.2.1-SNAPSHOT"
-    value: ${{ steps.compute.outputs.development-version }}
+    value: ${{ steps.compute.outputs.next-development-version }}
 
 runs:
   using: composite

--- a/.github/actions/maven-compute-release-versions/compute-versions.sh
+++ b/.github/actions/maven-compute-release-versions/compute-versions.sh
@@ -16,5 +16,6 @@ fi
 NEXT_VERSION="$(awk -F. -v OFS=. '{$NF=$NF+1; print}' <<< "${RELEASE_VERSION}")"
 DEVELOPMENT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is not set (this script must run in a GitHub Actions step)}"
 echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 echo "next-development-version=${DEVELOPMENT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/maven-compute-release-versions/compute-versions.sh
+++ b/.github/actions/maven-compute-release-versions/compute-versions.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+POM_VERSION=$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)
+RELEASE_VERSION="${POM_VERSION%-SNAPSHOT}"
+NEXT_VERSION=$(echo "${RELEASE_VERSION}" | awk -F. '{OFS="."; $NF=$NF+1; print $0}')
+DEVELOPMENT_VERSION="${NEXT_VERSION}-SNAPSHOT"
+
+echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+echo "development-version=${DEVELOPMENT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/maven-compute-release-versions/compute-versions.sh
+++ b/.github/actions/maven-compute-release-versions/compute-versions.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-POM_VERSION=$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)
+POM_VERSION="$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout | tr -d '\r')"
+if [[ -z "${POM_VERSION}" ]]; then
+  echo "Failed to evaluate Maven project.version (empty output)" >&2
+  exit 1
+fi
+
 RELEASE_VERSION="${POM_VERSION%-SNAPSHOT}"
-NEXT_VERSION=$(echo "${RELEASE_VERSION}" | awk -F. '{OFS="."; $NF=$NF+1; print $0}')
+if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  echo "Unsupported Maven project.version '${POM_VERSION}'. Expected a numeric dot-separated version with optional '-SNAPSHOT' suffix." >&2
+  exit 1
+fi
+
+NEXT_VERSION="$(awk -F. -v OFS=. '{$NF=$NF+1; print}' <<< "${RELEASE_VERSION}")"
 DEVELOPMENT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 
 echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/maven-compute-release-versions/compute-versions.sh
+++ b/.github/actions/maven-compute-release-versions/compute-versions.sh
@@ -17,4 +17,4 @@ NEXT_VERSION="$(awk -F. -v OFS=. '{$NF=$NF+1; print}' <<< "${RELEASE_VERSION}")"
 DEVELOPMENT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 
 echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-echo "development-version=${DEVELOPMENT_VERSION}" >> "$GITHUB_OUTPUT"
+echo "next-development-version=${DEVELOPMENT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
+++ b/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
@@ -68,3 +68,15 @@ assert_output_var() {
     assert_output_var "release-version"     "2.5.3"
     assert_output_var "next-development-version" "2.5.4-SNAPSHOT"
 }
+
+@test "fails on empty mvn output" {
+    export MOCK_POM_VERSION=""
+    run compute-versions.sh
+    [ "$status" -ne 0 ]
+}
+
+@test "fails on unsupported version format" {
+    export MOCK_POM_VERSION="1.0.0-RC1"
+    run compute-versions.sh
+    [ "$status" -ne 0 ]
+}

--- a/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
+++ b/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
@@ -27,7 +27,7 @@ assert_output_var() {
     run compute-versions.sh
     [ "$status" -eq 0 ]
     assert_output_var "release-version"     "26.2.0"
-    assert_output_var "development-version" "26.2.1-SNAPSHOT"
+    assert_output_var "next-development-version" "26.2.1-SNAPSHOT"
 }
 
 @test "patch rollover from 9 to 10" {
@@ -35,7 +35,7 @@ assert_output_var() {
     run compute-versions.sh
     [ "$status" -eq 0 ]
     assert_output_var "release-version"     "1.2.9"
-    assert_output_var "development-version" "1.2.10-SNAPSHOT"
+    assert_output_var "next-development-version" "1.2.10-SNAPSHOT"
 }
 
 @test "patch rollover from 99 to 100" {
@@ -43,7 +43,7 @@ assert_output_var() {
     run compute-versions.sh
     [ "$status" -eq 0 ]
     assert_output_var "release-version"     "3.0.99"
-    assert_output_var "development-version" "3.0.100-SNAPSHOT"
+    assert_output_var "next-development-version" "3.0.100-SNAPSHOT"
 }
 
 @test "patch zero is incremented to one" {
@@ -51,7 +51,7 @@ assert_output_var() {
     run compute-versions.sh
     [ "$status" -eq 0 ]
     assert_output_var "release-version"     "1.0.0"
-    assert_output_var "development-version" "1.0.1-SNAPSHOT"
+    assert_output_var "next-development-version" "1.0.1-SNAPSHOT"
 }
 
 @test "fails when mvn exits non-zero" {
@@ -66,5 +66,5 @@ assert_output_var() {
     run compute-versions.sh
     [ "$status" -eq 0 ]
     assert_output_var "release-version"     "2.5.3"
-    assert_output_var "development-version" "2.5.4-SNAPSHOT"
+    assert_output_var "next-development-version" "2.5.4-SNAPSHOT"
 }

--- a/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
+++ b/.github/actions/maven-compute-release-versions/tests/compute-versions.bats
@@ -1,0 +1,70 @@
+setup() {
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    PATH="$DIR/..:$PATH"
+
+    export GITHUB_OUTPUT="$BATS_TMPDIR/github_output_${RANDOM}"
+    > "$GITHUB_OUTPUT"
+
+    mvn() {
+        echo "${MOCK_POM_VERSION}"
+    }
+    export -f mvn
+}
+
+teardown() {
+    rm -f "$GITHUB_OUTPUT"
+}
+
+assert_output_var() {
+    local key="$1" expected="$2"
+    local actual
+    actual=$(grep "^${key}=" "$GITHUB_OUTPUT" | cut -d= -f2-)
+    [ "$actual" = "$expected" ] || { echo "Expected ${key}=${expected}, got ${key}=${actual}" >&2; return 1; }
+}
+
+@test "standard three-part SNAPSHOT version" {
+    export MOCK_POM_VERSION="26.2.0-SNAPSHOT"
+    run compute-versions.sh
+    [ "$status" -eq 0 ]
+    assert_output_var "release-version"     "26.2.0"
+    assert_output_var "development-version" "26.2.1-SNAPSHOT"
+}
+
+@test "patch rollover from 9 to 10" {
+    export MOCK_POM_VERSION="1.2.9-SNAPSHOT"
+    run compute-versions.sh
+    [ "$status" -eq 0 ]
+    assert_output_var "release-version"     "1.2.9"
+    assert_output_var "development-version" "1.2.10-SNAPSHOT"
+}
+
+@test "patch rollover from 99 to 100" {
+    export MOCK_POM_VERSION="3.0.99-SNAPSHOT"
+    run compute-versions.sh
+    [ "$status" -eq 0 ]
+    assert_output_var "release-version"     "3.0.99"
+    assert_output_var "development-version" "3.0.100-SNAPSHOT"
+}
+
+@test "patch zero is incremented to one" {
+    export MOCK_POM_VERSION="1.0.0-SNAPSHOT"
+    run compute-versions.sh
+    [ "$status" -eq 0 ]
+    assert_output_var "release-version"     "1.0.0"
+    assert_output_var "development-version" "1.0.1-SNAPSHOT"
+}
+
+@test "fails when mvn exits non-zero" {
+    mvn() { return 1; }
+    export -f mvn
+    run compute-versions.sh
+    [ "$status" -ne 0 ]
+}
+
+@test "non-SNAPSHOT input is used as-is for release version" {
+    export MOCK_POM_VERSION="2.5.3"
+    run compute-versions.sh
+    [ "$status" -eq 0 ]
+    assert_output_var "release-version"     "2.5.3"
+    assert_output_var "development-version" "2.5.4-SNAPSHOT"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1868,8 +1868,8 @@ Sample usage to prevent merging when tests are skipped:
 
 ### maven-compute-release-versions
 
-Derives the release version and next development version from the current POM `SNAPSHOT` version.
-Strips the `-SNAPSHOT` suffix to produce the release version, then increments the patch segment for the next development version.
+Derives the release version and next development version from the current POM version (typically a `-SNAPSHOT` version).
+Strips a trailing `-SNAPSHOT` suffix to produce the release version, then increments the last numeric segment for the next development version.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/maven-compute-release-versions@v18.19.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1879,10 +1879,10 @@ Strips the `-SNAPSHOT` suffix to produce the release version, then increments th
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           release-version: ${{ steps.versions.outputs.release-version }}
-          development-version: ${{ steps.versions.outputs.development-version }}
+          development-version: ${{ steps.versions.outputs.next-development-version }}
 ```
 
-Maven must be available before invoking this action. Given a POM version of `26.2.0-SNAPSHOT`, the action produces `release-version=26.2.0` and `development-version=26.2.1-SNAPSHOT`.
+Maven must be available before invoking this action. Given a POM version of `26.2.0-SNAPSHOT`, the action produces `release-version=26.2.0` and `next-development-version=26.2.1-SNAPSHOT`.
 
 ### maven-deploy-file
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [maven-dependency-scan](#maven-dependency-scan)
   - [maven-build](#maven-build)
   - [maven-build-and-tag](#maven-build-and-tag)
+  - [maven-compute-release-versions](#maven-compute-release-versions)
   - [maven-deploy-file](#maven-deploy-file)
   - [maven-release](#maven-release)
   - [maven-release-slim](#maven-release-slim)
@@ -1864,6 +1865,24 @@ Sample usage to prevent merging when tests are skipped:
         echo "This pull request can be merged."
       fi
 ```
+
+### maven-compute-release-versions
+
+Derives the release version and next development version from the current POM `SNAPSHOT` version.
+Strips the `-SNAPSHOT` suffix to produce the release version, then increments the patch segment for the next development version.
+
+```yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-compute-release-versions@v18.19.0
+        id: versions
+
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-release-slim@v18.19.0
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          release-version: ${{ steps.versions.outputs.release-version }}
+          development-version: ${{ steps.versions.outputs.development-version }}
+```
+
+Maven must be available before invoking this action. Given a POM version of `26.2.0-SNAPSHOT`, the action produces `release-version=26.2.0` and `development-version=26.2.1-SNAPSHOT`.
 
 ### maven-deploy-file
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): https://hyland.atlassian.net/browse/ACS-12079
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:
- https://github.com/Alfresco/alfresco-community-repo/actions/runs/29840031364/job/88666264306
- https://github.com/Alfresco/alfresco-community-repo/pull/4221

### Description

This PR it to add a new `maven-compute-release-versions` composite action that derives `release-version` and `development-version` from the current POM `SNAPSHOT` version.
Action strips the `-SNAPSHOT` suffix for the release version and increments the patch segment for the next development version.

The action reads the POM version via `mvn help:evaluate`, then computes:
  - `release-version`: e.g. `26.2.0-SNAPSHOT` → `26.2.0`
  - `development-version`: e.g. `26.2.0` → `26.2.1-SNAPSHOT`
