### PR TITLE
AAE-49271 Skip redundant maven cache save on exact cache hit

### DIFF
--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -254,9 +254,18 @@ runs:
         rm -fr ~/.m2/repository/org/activiti
         rm -fr ~/.m2/repository/com/alfresco
 
+    - name: Check maven cache
+      id: check-maven-cache
+      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        lookup-only: true
+
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
+      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.check-maven-cache.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/maven-build-and-tag/action.yml
+++ b/.github/actions/maven-build-and-tag/action.yml
@@ -254,18 +254,9 @@ runs:
         rm -fr ~/.m2/repository/org/activiti
         rm -fr ~/.m2/repository/com/alfresco
 
-    - name: Check maven cache
-      id: check-maven-cache
-      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        lookup-only: true
-
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.check-maven-cache.outputs.cache-hit != 'true'
+      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.maven-configure.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ steps.maven-configure.outputs.cache-primary-key }}

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -247,9 +247,18 @@ runs:
           rm -fr ~/.m2/repository/${EXCLUSION_PATTERN}
         fi
 
+    - name: Check maven cache
+      id: check-maven-cache
+      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        lookup-only: true
+
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
+      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.check-maven-cache.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -247,18 +247,9 @@ runs:
           rm -fr ~/.m2/repository/${EXCLUSION_PATTERN}
         fi
 
-    - name: Check maven cache
-      id: check-maven-cache
-      if: github.event_name == 'push' || env.IS_PREVIEW == 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        lookup-only: true
-
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.check-maven-cache.outputs.cache-hit != 'true'
+      if: (github.event_name == 'push' || env.IS_PREVIEW == 'true') && steps.maven-configure.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ steps.maven-configure.outputs.cache-primary-key }}

--- a/.github/actions/maven-configure/action.yml
+++ b/.github/actions/maven-configure/action.yml
@@ -45,11 +45,19 @@ outputs:
   preview-version:
     description: The preview version when it's a preview.
     value: ${{ steps.set-preview-version.outputs.preview-version }}
+  cache-hit:
+    description: Whether an exact match was found for the Maven repository cache primary key.
+    value: ${{ steps.restore-maven-cache.outputs.cache-hit }}
+  cache-primary-key:
+    description: The primary key used to restore the Maven repository cache.
+    value: ${{ steps.restore-maven-cache.outputs.cache-primary-key }}
 
 runs:
   using: composite
   steps:
-    - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Restore maven cache
+      id: restore-maven-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/maven-tag/action.yml
+++ b/.github/actions/maven-tag/action.yml
@@ -75,8 +75,17 @@ runs:
           rm -fr ~/.m2/repository/${EXCLUSION_PATTERN}
         fi
 
+    - name: Check maven cache
+      id: check-maven-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        lookup-only: true
+
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      if: steps.check-maven-cache.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/maven-tag/action.yml
+++ b/.github/actions/maven-tag/action.yml
@@ -75,20 +75,12 @@ runs:
           rm -fr ~/.m2/repository/${EXCLUSION_PATTERN}
         fi
 
-    - name: Check maven cache
-      id: check-maven-cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        lookup-only: true
-
     - name: Save maven cache
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: steps.check-maven-cache.outputs.cache-hit != 'true'
+      if: steps.maven-configure.outputs.cache-hit != 'true'
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ steps.maven-configure.outputs.cache-primary-key }}
 
     - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@0a318b94438ac17713a239ea444c77c05bf11097
       with:


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): [AAE-49271](https://hyland.atlassian.net/browse/AAE-49271)
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

When many parallel jobs share the same Maven cache key (`${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}`), each job restores an exact hit and then still attempts to save the cache back under the identical key. Only the first save wins; the rest fail with `Unable to reserve cache with key ..., another job may be creating this cache` and emit a `Cache save failed` warning. The build stays green, but every losing job wastes time compressing the whole `~/.m2/repository` (~700 MB+) before the reservation is rejected.

The Maven cache is restored once, in the `maven-configure` action. That action now exposes two outputs from its `actions/cache/restore` step:

- `cache-primary-key` — the primary key used to restore the cache.
- `cache-hit` — whether the restore was an exact match.

`maven-build`, `maven-build-and-tag`, and `maven-tag` now consume those outputs: the "Save maven cache" step keys off `steps.maven-configure.outputs.cache-primary-key` and only runs when `steps.maven-configure.outputs.cache-hit != 'true'` (a genuine miss). This mirrors the built-in behaviour of the combined `actions/cache` action, deriving both the key and the hit from the single restore instead of re-declaring the key at each save site.

Effect:
- No redundant saves (and no `Cache save failed` warnings) when the exact key already exists.
- Eliminates the wasted `~/.m2/repository` compression across the parallel matrix.
- The cache key is defined once (in `maven-configure`) and reused via output — no hardcoded key duplicated across the save actions.
- The change is internal to the shared actions — no changes required in consuming workflows; existing inputs/outputs and usage are unchanged.


[AAE-49271]: https://hyland.atlassian.net/browse/AAE-49271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ