### PR TITLE
OPSEXP-4229 Switch terraform concurrency to queue strategy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -309,7 +309,7 @@ jobs:
       deployment: ${{ needs.compute_basic_vars.outputs.terraform_operation != 'plan' }}
     concurrency:
       group: ${{ needs.compute_basic_vars.outputs.environment_name }}
-      cancel-in-progress: false
+      queue: max
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: '(.*/dist/.*|\.github/workflows/.*\.lock\.yml$)'
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-actions
@@ -34,6 +34,7 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+        args: [-ignore, 'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"']
         exclude: ^(\.github/tests/|\.github/workflows/.*\.lock\.yml$)
 
   - repo: https://github.com/hyland/github-actions-ensure-sha-pinned-actions


### PR DESCRIPTION
Updates the terraform workflow to use the `queue: max` concurrency strategy instead of `cancel-in-progress: false`.

Also adds actionlint ignore rule for the newer `queue` option which the current version of actionlint doesn't recognize.

OPSEXP-4229