### PR TITLE
OPSEXP-4208 Filter extracted Jira tickets to the configured project before setting fix version

### DIFF
--- a/.github/actions/jira-propagate-release/action.yml
+++ b/.github/actions/jira-propagate-release/action.yml
@@ -59,6 +59,7 @@ runs:
         TICKET_REGEX: ${{ inputs.ticket-regex }}
         GITHUB_VERSION_PREFIX: ${{ inputs.github-version-prefix }}
         JIRA_VERSION_PREFIX: ${{ inputs.jira-version-prefix }}
+        JIRA_PROJECT_KEY: ${{ inputs.jira-project-key }}
       run: |
         "${{ github.action_path }}/extract-tickets-from-release-payload.sh"
 

--- a/.github/actions/jira-propagate-release/extract-tickets-from-release-payload.sh
+++ b/.github/actions/jira-propagate-release/extract-tickets-from-release-payload.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #   GITHUB_OUTPUT                 If set, write outputs there (GitHub Actions outputs file)
 #   GITHUB_VERSION_PREFIX         Prefix to remove from GitHub tag (literal match)
 #   JIRA_VERSION_PREFIX           Prefix to prepend to Jira version name
+#   JIRA_PROJECT_KEY              If set, keep only extracted tickets belonging to this Jira project (e.g. "ABC")
 #
 # Output keys:
 #   tickets-csv=ABC-1,DEF-2        Comma-separated list of unique ticket IDs (empty if none found)
@@ -87,6 +88,10 @@ if [[ ${grep_status} -eq 2 ]]; then
   echo "::error::Invalid TICKET_REGEX '${TICKET_REGEX}':"
   cat grep_err.txt >&2
   exit 1
+fi
+
+if [[ -n "${JIRA_PROJECT_KEY:-}" && -n "${MATCHES}" ]]; then
+  MATCHES="$(printf '%s\n' "${MATCHES}" | grep -E "^${JIRA_PROJECT_KEY}-[0-9]+$" || true)"
 fi
 
 if [[ -z "${MATCHES}" ]]; then

--- a/.github/actions/jira-propagate-release/tests/extract_tickets_from_release_payload.bats
+++ b/.github/actions/jira-propagate-release/tests/extract_tickets_from_release_payload.bats
@@ -153,6 +153,42 @@ JSON
   grep -qx "tickets-csv=OPS-22,TC-1" "${out_file}"
 }
 
+@test "JIRA_PROJECT_KEY filters out tickets from other projects" {
+  make_payload "v1.2.3" "Release" "Fixes ACS-11432, OPSEXP-3962 and OPSEXP-4138"
+  out_file="$(mktemp)"
+
+  run env \
+    GITHUB_OUTPUT="${out_file}" \
+    JIRA_PROJECT_KEY="OPSEXP" \
+    bash "${SCRIPT}" "${payload}"
+
+  [ "$status" -eq 0 ]
+  grep -qx "tickets-csv=OPSEXP-3962,OPSEXP-4138" "${out_file}"
+}
+
+@test "no JIRA_PROJECT_KEY → no filtering (backward compatible)" {
+  make_payload "v1.2.3" "Release" "Fixes ACS-11432, OPSEXP-3962"
+  out_file="$(mktemp)"
+
+  run env GITHUB_OUTPUT="${out_file}" bash "${SCRIPT}" "${payload}"
+
+  [ "$status" -eq 0 ]
+  grep -qx "tickets-csv=ACS-11432,OPSEXP-3962" "${out_file}"
+}
+
+@test "JIRA_PROJECT_KEY matching none → empty tickets-csv" {
+  make_payload "v1.2.3" "Release" "Fixes ACS-11432"
+  out_file="$(mktemp)"
+
+  run env \
+    GITHUB_OUTPUT="${out_file}" \
+    JIRA_PROJECT_KEY="OPSEXP" \
+    bash "${SCRIPT}" "${payload}"
+
+  [ "$status" -eq 0 ]
+  grep -qx "tickets-csv=" "${out_file}"
+}
+
 # --------------------------------------------------
 # 🛡️ Robustness
 # --------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): OPSEXP-4208
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

`jira-propagate-release` extracts Jira ticket keys from the GitHub release payload (name, tag, URL, body) with a project-agnostic regex, then passes all of them to `jira-set-fix-version` to stamp the release's Fix Version. `jira-set-fix-version` only supports a single project per run (it derives the project from the first issue key and enforces all issues belong to it), and the Fix Version is only ever created in the single project configured via `jira-project-key`. When the release notes happened to reference a ticket from a different Jira project (e.g. `ACS-11432` alongside the intended `OPSEXP-*` tickets), the whole step hard-failed because that version doesn't exist in the unrelated project, even though the intended tickets would have updated fine. This is what broke https://github.com/Alfresco/acs-deployment/actions/runs/30633986769/job/91166856127.

This PR filters the extracted ticket list down to only tickets belonging to the configured `jira-project-key` before handing them to `jira-set-fix-version`, via a new optional `JIRA_PROJECT_KEY` env var on `extract-tickets-from-release-payload.sh` (wired from the existing `jira-project-key` action input, no new inputs added). Added bats coverage for the filtering behavior and confirmed it's backward compatible when the key is unset.

OPSEXP-4208