### PR TITLE
OPSEXP-4275 Gate comment-triggered terraform apply on PR approval

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -318,7 +318,7 @@ jobs:
             deny "PR #${PR_NUMBER} is ${pr_state}: terraform ${TERRAFORM_OPERATION} can only be triggered from a comment on an open pull request."
           fi
 
-          if [ "$TERRAFORM_OPERATION" == "apply" ]; then
+          if [ "$TERRAFORM_OPERATION" == "apply" ] && [ "$commenter_permission" != "admin" ]; then
             # honours required reviewers and CODEOWNERS rules from branch protection;
             # empty when the base branch has no required-review rule configured
             review_decision=$(jq -r '.reviewDecision // ""' <<< "$pr_data")

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -245,10 +245,18 @@ jobs:
           IS_PULL_REQUEST_EVENT: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' }}
           IS_PUSH_EVENT: ${{ github.event_name == 'push' }}
           IS_ISSUE_COMMENT_EVENT: ${{ github.event_name == 'issue_comment' }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request.html_url != '' }}
           COMMENT_REQUESTS_PLAN: ${{ contains(github.event.comment.body, 'terraform plan') }}
           COMMENT_REQUESTS_APPLY: ${{ contains(github.event.comment.body, 'terraform apply') }}
           TERRAFORM_OPERATION_FROM_INPUTS: ${{ inputs.terraform_operation }}
         run: |
+          # issue_comment is also fired by comments on plain issues
+          if [[ "$IS_ISSUE_COMMENT_EVENT" == "true" ]] && [[ "$IS_PR_COMMENT" != "true" ]]; then
+            echo "Comment was made on a plain issue, not a pull request. Skipping."
+            echo "terraform_operation=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Resolve a single operation with precedence: plan > apply > destroy
           if [[ "$IS_PULL_REQUEST_EVENT" == "true" ]] || [[ "$TERRAFORM_OPERATION_FROM_INPUTS" == "plan" ]] || { [[ "$IS_ISSUE_COMMENT_EVENT" == "true" ]] && [[ "$COMMENT_REQUESTS_PLAN" == "true" ]]; }; then
             operation="plan"
@@ -268,59 +276,58 @@ jobs:
           echo "Determined terraform operation: $operation"
           echo "terraform_operation=${operation}" >> "$GITHUB_OUTPUT"
 
-      - name: Authorize terraform apply requested via PR comment
+      - name: Authorize terraform plan/apply requested via PR comment
         # Only PR comments can be authored by an untrusted user: push is guarded by
         # branch protection and workflow_dispatch by the Actions permission model.
-        if: github.event_name == 'issue_comment' && steps.operation.outputs.terraform_operation == 'apply'
+        if: |
+          github.event_name == 'issue_comment' &&
+          (steps.operation.outputs.terraform_operation == 'plan' || steps.operation.outputs.terraform_operation == 'apply')
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
-          PR_HTML_URL: ${{ github.event.issue.pull_request.html_url }}
           COMMENTER: ${{ github.event.comment.user.login }}
+          TERRAFORM_OPERATION: ${{ steps.operation.outputs.terraform_operation }}
         run: |
           deny() {
             echo "::error::$1"
             {
-              echo "### Terraform apply denied 🛑"
+              echo "### Terraform ${TERRAFORM_OPERATION} denied 🛑"
               echo "$1"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
-          # issue_comment is also fired by comments on plain issues
-          if [ -z "$PR_HTML_URL" ]; then
-            deny "terraform apply was requested from a comment which is not on a pull request."
-          fi
-
           if ! commenter_permission=$(gh api "repos/${REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission'); then
-            deny "Unable to resolve the permission of @${COMMENTER} on ${REPOSITORY}, refusing to run terraform apply."
+            deny "Unable to resolve the permission of @${COMMENTER} on ${REPOSITORY}, refusing to run terraform ${TERRAFORM_OPERATION}."
           fi
 
           case "$commenter_permission" in
             admin | maintain | write) ;;
             *)
-              deny "@${COMMENTER} has '${commenter_permission}' permission on ${REPOSITORY}: triggering terraform apply from a PR comment requires write, maintain or admin permission."
+              deny "@${COMMENTER} has '${commenter_permission}' permission on ${REPOSITORY}: triggering terraform ${TERRAFORM_OPERATION} from a PR comment requires write, maintain or admin permission."
               ;;
           esac
 
           if ! pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state,reviewDecision); then
-            deny "Unable to fetch the review status of PR #${PR_NUMBER}, refusing to run terraform apply."
+            deny "Unable to fetch the review status of PR #${PR_NUMBER}, refusing to run terraform ${TERRAFORM_OPERATION}."
           fi
 
           pr_state=$(jq -r '.state' <<< "$pr_data")
           if [ "$pr_state" != "OPEN" ]; then
-            deny "PR #${PR_NUMBER} is ${pr_state}: terraform apply can only be triggered from a comment on an open pull request."
+            deny "PR #${PR_NUMBER} is ${pr_state}: terraform ${TERRAFORM_OPERATION} can only be triggered from a comment on an open pull request."
           fi
 
-          # honours required reviewers and CODEOWNERS rules from branch protection;
-          # empty when the base branch has no required-review rule configured
-          review_decision=$(jq -r '.reviewDecision // ""' <<< "$pr_data")
-          if [ "$review_decision" != "APPROVED" ]; then
-            deny "PR #${PR_NUMBER} is not approved (review decision: '${review_decision}'): terraform apply can only be triggered from a comment on an approved pull request. Ensure branch protection with required reviews is enabled on the base branch."
+          if [ "$TERRAFORM_OPERATION" == "apply" ]; then
+            # honours required reviewers and CODEOWNERS rules from branch protection;
+            # empty when the base branch has no required-review rule configured
+            review_decision=$(jq -r '.reviewDecision // ""' <<< "$pr_data")
+            if [ "$review_decision" != "APPROVED" ]; then
+              deny "PR #${PR_NUMBER} is not approved (review decision: '${review_decision}'): terraform apply can only be triggered from a comment on an approved pull request. Ensure branch protection with required reviews is enabled on the base branch."
+            fi
           fi
 
-          echo "@${COMMENTER} (${commenter_permission}) is allowed to trigger terraform apply on the approved PR #${PR_NUMBER}"
+          echo "@${COMMENTER} (${commenter_permission}) is allowed to trigger terraform ${TERRAFORM_OPERATION} on PR #${PR_NUMBER}"
 
       - name: Add workflow summary info
         env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -268,6 +268,67 @@ jobs:
           echo "Determined terraform operation: $operation"
           echo "terraform_operation=${operation}" >> "$GITHUB_OUTPUT"
 
+      - name: Authorize terraform apply requested via PR comment
+        # Only PR comments can be authored by an untrusted user: push is guarded by
+        # branch protection and workflow_dispatch by the Actions permission model.
+        if: github.event_name == 'issue_comment' && steps.operation.outputs.terraform_operation == 'apply'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_HTML_URL: ${{ github.event.issue.pull_request.html_url }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          deny() {
+            echo "::error::$1"
+            {
+              echo "### Terraform apply denied 🛑"
+              echo "$1"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          # issue_comment is also fired by comments on plain issues
+          if [ -z "$PR_HTML_URL" ]; then
+            deny "terraform apply was requested from a comment which is not on a pull request."
+          fi
+
+          if ! commenter_permission=$(gh api "repos/${REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission'); then
+            deny "Unable to resolve the permission of @${COMMENTER} on ${REPOSITORY}, refusing to run terraform apply."
+          fi
+
+          case "$commenter_permission" in
+            admin | maintain | write) ;;
+            *)
+              deny "@${COMMENTER} has '${commenter_permission}' permission on ${REPOSITORY}: triggering terraform apply from a PR comment requires write, maintain or admin permission."
+              ;;
+          esac
+
+          if ! pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state,reviewDecision,latestReviews); then
+            deny "Unable to fetch the review status of PR #${PR_NUMBER}, refusing to run terraform apply."
+          fi
+
+          pr_state=$(jq -r '.state' <<< "$pr_data")
+          if [ "$pr_state" != "OPEN" ]; then
+            deny "PR #${PR_NUMBER} is ${pr_state}: terraform apply can only be triggered from a comment on an open pull request."
+          fi
+
+          review_decision=$(jq -r '.reviewDecision // ""' <<< "$pr_data")
+          if [ -n "$review_decision" ]; then
+            # honours required reviewers and CODEOWNERS rules from branch protection
+            if [ "$review_decision" != "APPROVED" ]; then
+              deny "PR #${PR_NUMBER} is not approved (review decision: ${review_decision}): terraform apply can only be triggered from a comment on an approved pull request."
+            fi
+          else
+            echo "::warning::The base branch of PR #${PR_NUMBER} does not require reviews, falling back to looking for at least one approving review. Enabling branch protection with required reviews is strongly recommended."
+            approvals=$(jq '[.latestReviews[]? | select(.state == "APPROVED")] | length' <<< "$pr_data")
+            if [ "${approvals:-0}" -lt 1 ]; then
+              deny "PR #${PR_NUMBER} has no approving review: terraform apply can only be triggered from a comment on an approved pull request."
+            fi
+          fi
+
+          echo "@${COMMENTER} (${commenter_permission}) is allowed to trigger terraform apply on the approved PR #${PR_NUMBER}"
+
       - name: Add workflow summary info
         env:
           TERRAFORM_ROOT_PATH: ${{ (steps.detect-path.outputs.terraform_root_path || inputs.terraform_root_path) }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -304,7 +304,7 @@ jobs:
               ;;
           esac
 
-          if ! pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state,reviewDecision,latestReviews); then
+          if ! pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state,reviewDecision); then
             deny "Unable to fetch the review status of PR #${PR_NUMBER}, refusing to run terraform apply."
           fi
 
@@ -313,18 +313,11 @@ jobs:
             deny "PR #${PR_NUMBER} is ${pr_state}: terraform apply can only be triggered from a comment on an open pull request."
           fi
 
+          # honours required reviewers and CODEOWNERS rules from branch protection;
+          # empty when the base branch has no required-review rule configured
           review_decision=$(jq -r '.reviewDecision // ""' <<< "$pr_data")
-          if [ -n "$review_decision" ]; then
-            # honours required reviewers and CODEOWNERS rules from branch protection
-            if [ "$review_decision" != "APPROVED" ]; then
-              deny "PR #${PR_NUMBER} is not approved (review decision: ${review_decision}): terraform apply can only be triggered from a comment on an approved pull request."
-            fi
-          else
-            echo "::warning::The base branch of PR #${PR_NUMBER} does not require reviews, falling back to looking for at least one approving review. Enabling branch protection with required reviews is strongly recommended."
-            approvals=$(jq '[.latestReviews[]? | select(.state == "APPROVED")] | length' <<< "$pr_data")
-            if [ "${approvals:-0}" -lt 1 ]; then
-              deny "PR #${PR_NUMBER} has no approving review: terraform apply can only be triggered from a comment on an approved pull request."
-            fi
+          if [ "$review_decision" != "APPROVED" ]; then
+            deny "PR #${PR_NUMBER} is not approved (review decision: '${review_decision}'): terraform apply can only be triggered from a comment on an approved pull request. Ensure branch protection with required reviews is enabled on the base branch."
           fi
 
           echo "@${COMMENTER} (${commenter_permission}) is allowed to trigger terraform apply on the approved PR #${PR_NUMBER}"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -302,13 +302,6 @@ jobs:
             deny "Unable to resolve the permission of @${COMMENTER} on ${REPOSITORY}, refusing to run terraform ${TERRAFORM_OPERATION}."
           fi
 
-          case "$commenter_permission" in
-            admin | maintain | write) ;;
-            *)
-              deny "@${COMMENTER} has '${commenter_permission}' permission on ${REPOSITORY}: triggering terraform ${TERRAFORM_OPERATION} from a PR comment requires write, maintain or admin permission."
-              ;;
-          esac
-
           if ! pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state,reviewDecision); then
             deny "Unable to fetch the review status of PR #${PR_NUMBER}, refusing to run terraform ${TERRAFORM_OPERATION}."
           fi

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -169,31 +169,39 @@ When the workflow is triggered by a PR comment, it will look for the presence of
 the strings `terraform plan` or `terraform apply` in the comment body to determine
 the requested operation. When both are present, `terraform plan` takes precedence.
 
-Requesting `terraform apply` from a PR comment is allowed only when **all** of the
-following conditions are met, otherwise the workflow fails with an error:
+`issue_comment` events also fire for comments on plain issues, not just pull
+requests. When a comment requesting `terraform plan` or `terraform apply` is made
+on a plain issue, the request is silently skipped, without failing the workflow.
 
-- the comment is on a pull request (not on a plain issue), and that pull request
-  is still open
-- the pull request is approved: the GitHub review decision must be `APPROVED`,
-  which honours the required reviewers and `CODEOWNERS` rules configured through
-  branch protection. This requires branch protection with required reviews to be
-  enabled on the base branch; otherwise the review decision is never `APPROVED`
-  and the operation is always denied
+Requesting `terraform plan` or `terraform apply` from a PR comment is allowed only
+when **all** of the following conditions are met, otherwise the workflow fails
+with an error:
+
+- the pull request is still open
 - the author of the comment has `write`, `maintain` or `admin` permission on the
   repository
+
+Requesting `terraform apply` additionally requires the pull request to be
+approved: the GitHub review decision must be `APPROVED`, which honours the
+required reviewers and `CODEOWNERS` rules configured through branch protection.
+This requires branch protection with required reviews to be enabled on the base
+branch; otherwise the review decision is never `APPROVED` and the operation is
+always denied. This extra condition does not apply to `terraform plan`, since it
+is meant to be used to review changes before approving the pull request.
 
 Any error while verifying the conditions above (for example a missing token
 permission) denies the operation.
 
-These restrictions do not apply to `terraform plan` requested from a comment, nor
-to the `push` and `workflow_dispatch` triggers, which are guarded respectively by
-branch protection rules and by the repository Actions permissions. Enabling
-deployment protection rules on production environments is still recommended.
+These restrictions do not apply to the `push` and `workflow_dispatch` triggers,
+which are guarded respectively by branch protection rules and by the repository
+Actions permissions. Enabling deployment protection rules on production
+environments is still recommended.
 
 The caller workflow must grant at least `pull-requests: read` to `GITHUB_TOKEN`
 (`pull-requests: write` is recommended anyway, as it is required to publish the
 plan output as a PR comment), otherwise the verification above cannot be
-performed and `terraform apply` from a PR comment is always denied.
+performed and `terraform plan`/`terraform apply` from a PR comment is always
+denied.
 
 ### Environment variables
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -176,11 +176,9 @@ following conditions are met, otherwise the workflow fails with an error:
   is still open
 - the pull request is approved: the GitHub review decision must be `APPROVED`,
   which honours the required reviewers and `CODEOWNERS` rules configured through
-  branch protection. If the base branch does not require reviews at all, the
-  workflow falls back to requiring at least one approving review which has not
-  been dismissed, and emits a warning: configuring branch protection with
-  required reviews on the branches driving your infrastructure is strongly
-  recommended
+  branch protection. This requires branch protection with required reviews to be
+  enabled on the base branch; otherwise the review decision is never `APPROVED`
+  and the operation is always denied
 - the author of the comment has `write`, `maintain` or `admin` permission on the
   repository
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -174,12 +174,7 @@ requests. When a comment requesting `terraform plan` or `terraform apply` is mad
 on a plain issue, the request is silently skipped, without failing the workflow.
 
 Requesting `terraform plan` or `terraform apply` from a PR comment is allowed only
-when **all** of the following conditions are met, otherwise the workflow fails
-with an error:
-
-- the pull request is still open
-- the author of the comment has `write`, `maintain` or `admin` permission on the
-  repository
+while the pull request is still open, otherwise the workflow fails with an error.
 
 Requesting `terraform apply` additionally requires the pull request to be
 approved: the GitHub review decision must be `APPROVED`, which honours the

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -167,11 +167,35 @@ matching the branch name (`base_ref` for `pull_request`, `ref_name` for `push`).
 
 When the workflow is triggered by a PR comment, it will look for the presence of
 the strings `terraform plan` or `terraform apply` in the comment body to determine
-the requested operation.
+the requested operation. When both are present, `terraform plan` takes precedence.
 
-Currently there are no additional restrictions on who/when can trigger terraform
-operations via PR comments, so it's recommended to enable deployment protection
-rules on production environments.
+Requesting `terraform apply` from a PR comment is allowed only when **all** of the
+following conditions are met, otherwise the workflow fails with an error:
+
+- the comment is on a pull request (not on a plain issue), and that pull request
+  is still open
+- the pull request is approved: the GitHub review decision must be `APPROVED`,
+  which honours the required reviewers and `CODEOWNERS` rules configured through
+  branch protection. If the base branch does not require reviews at all, the
+  workflow falls back to requiring at least one approving review which has not
+  been dismissed, and emits a warning: configuring branch protection with
+  required reviews on the branches driving your infrastructure is strongly
+  recommended
+- the author of the comment has `write`, `maintain` or `admin` permission on the
+  repository
+
+Any error while verifying the conditions above (for example a missing token
+permission) denies the operation.
+
+These restrictions do not apply to `terraform plan` requested from a comment, nor
+to the `push` and `workflow_dispatch` triggers, which are guarded respectively by
+branch protection rules and by the repository Actions permissions. Enabling
+deployment protection rules on production environments is still recommended.
+
+The caller workflow must grant at least `pull-requests: read` to `GITHUB_TOKEN`
+(`pull-requests: write` is recommended anyway, as it is required to publish the
+plan output as a PR comment), otherwise the verification above cannot be
+performed and `terraform apply` from a PR comment is always denied.
 
 ### Environment variables
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -186,8 +186,10 @@ approved: the GitHub review decision must be `APPROVED`, which honours the
 required reviewers and `CODEOWNERS` rules configured through branch protection.
 This requires branch protection with required reviews to be enabled on the base
 branch; otherwise the review decision is never `APPROVED` and the operation is
-always denied. This extra condition does not apply to `terraform plan`, since it
-is meant to be used to review changes before approving the pull request.
+denied. This extra condition does not apply to `terraform plan`, since it is
+meant to be used to review changes before approving the pull request, nor to
+commenters with `admin` permission on the repository, who can trigger
+`terraform apply` on an open pull request regardless of its review decision.
 
 Any error while verifying the conditions above (for example a missing token
 permission) denies the operation.


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): OPSEXP-4275
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-alfresco-nexus/pull/356

### Description

Gates `terraform plan` and `terraform apply` requested via a PR comment behind an authorization check, since a PR comment (unlike `push` or `workflow_dispatch`) can be authored by an untrusted user. The new step denies the request unless the pull request is open. `terraform apply` additionally requires the pull request's GitHub review decision to be `APPROVED` — which honours required reviewers and CODEOWNERS rules from branch protection, and requires branch protection with required reviews to be enabled on the base branch, otherwise the review decision is never `APPROVED` and the operation is denied — unless the commenter has `admin` permission, in which case the approval check is bypassed. The approval requirement doesn't apply to `terraform plan`, since it's meant to be used to review changes before approving. The `push`/`workflow_dispatch` triggers are unaffected since they are already guarded by branch protection and the Actions permission model respectively.

A comment requesting `terraform plan`/`terraform apply` on a plain issue (not a pull request) — `issue_comment` fires for both — is silently skipped rather than failing the workflow.

`docs/terraform.md` documents the new restrictions.