### PR TITLE
ACS-12079 Extend maven-release-slim action

### DIFF
--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -31,10 +31,6 @@ inputs:
     required: false
     description: Boolean forwarded to verified-bot-commit's "update-local" input. Defaults to "true".
     default: 'true'
-  force-lf-eol:
-    required: false
-    description: Boolean to force LF line endings on the committed pom.xml files before committing. Defaults to "false".
-    default: 'false'
 
 runs:
   using: composite
@@ -45,11 +41,6 @@ runs:
 
     - name: "Deploy release version ${{ inputs.release-version }}"
       run: mvn -B -ntp clean deploy -P ${{ inputs.release-profile }} -Dproject.revision.key=${{ github.sha }} ${{ inputs.maven-args }}
-      shell: bash
-
-    - name: "Force LF line endings on pom.xml files"
-      if: inputs.force-lf-eol == 'true'
-      run: git ls-files -z -- pom.xml '**/pom.xml' | xargs -0 -r sed -i 's/\r$//'
       shell: bash
 
     - name: "Commit release version ${{ inputs.release-version }}"
@@ -71,11 +62,6 @@ runs:
 
     - name: "Set next development version to ${{ inputs.development-version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
-      shell: bash
-
-    - name: "Force LF line endings on pom.xml files"
-      if: inputs.force-lf-eol == 'true'
-      run: git ls-files -z -- pom.xml '**/pom.xml' | xargs -0 -r sed -i 's/\r$//'
       shell: bash
 
     - name: "Commit next development version ${{ inputs.development-version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -27,6 +27,14 @@ inputs:
     required: false
     description: Prefix used by bot for commit message. Defaults to "[skip ci]".
     default: '[skip ci]'
+  update-local:
+    required: false
+    description: Boolean forwarded to verified-bot-commit's "update-local" input. Defaults to "true".
+    default: 'true'
+  force-lf-eol:
+    required: false
+    description: Boolean to force LF line endings on the committed pom.xml files before committing. Defaults to "false".
+    default: 'false'
 
 runs:
   using: composite
@@ -39,11 +47,17 @@ runs:
       run: mvn -B -ntp clean deploy -P ${{ inputs.release-profile }} -Dproject.revision.key=${{ github.sha }} ${{ inputs.maven-args }}
       shell: bash
 
+    - name: "Force LF line endings on pom.xml files"
+      if: inputs.force-lf-eol == 'true'
+      run: git ls-files -z -- pom.xml '**/pom.xml' | xargs -0 -r sed -i 's/\r$//'
+      shell: bash
+
     - name: "Commit release version ${{ inputs.release-version }}"
       uses: iarekylew00t/verified-bot-commit@1ccc6afd0f789e8442cff7deec3e9856a693cc7e # v2.3.4
       with:
         token: ${{ inputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        update-local: ${{ inputs.update-local }}
         files: |
           pom.xml
           **/pom.xml
@@ -59,11 +73,17 @@ runs:
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
       shell: bash
 
+    - name: "Force LF line endings on pom.xml files"
+      if: inputs.force-lf-eol == 'true'
+      run: git ls-files -z -- pom.xml '**/pom.xml' | xargs -0 -r sed -i 's/\r$//'
+      shell: bash
+
     - name: "Commit next development version ${{ inputs.development-version }}"
       uses: iarekylew00t/verified-bot-commit@1ccc6afd0f789e8442cff7deec3e9856a693cc7e # v2.3.4
       with:
         token: ${{ inputs.token }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        update-local: ${{ inputs.update-local }}
         files: |
           pom.xml
           **/pom.xml

--- a/docs/README.md
+++ b/docs/README.md
@@ -1950,7 +1950,6 @@ A lightweight Maven release action that sets the release version, deploys the ar
           create-tag: 'true'  # optional, default: 'true'
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
           update-local: 'true'  # optional, default: 'true', forwarded to verified-bot-commit's update-local input
-          force-lf-eol: 'false'  # optional, default: 'false', forces LF line endings on the committed pom.xml files before committing
 ```
 
 Java and Maven should be set up before invoking the action. The provided `token` must have write access to the repository contents to push the release/development version commits and (if enabled) the release tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1949,6 +1949,8 @@ A lightweight Maven release action that sets the release version, deploys the ar
           maven-args: -DskipTests  # optional, default: -DskipTests
           create-tag: 'true'  # optional, default: 'true'
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
+          update-local: 'true'  # optional, default: 'true', forwarded to verified-bot-commit's update-local input
+          force-lf-eol: 'false'  # optional, default: 'false', forces LF line endings on the committed pom.xml files before committing
 ```
 
 Java and Maven should be set up before invoking the action. The provided `token` must have write access to the repository contents to push the release/development version commits and (if enabled) the release tag.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): https://hyland.atlassian.net/browse/ACS-12079
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

This PR is to add two new inputs `update-local` and `force-lf-eol`. 
Steps were tested in the following build: https://github.com/Alfresco/acs-packaging/actions/runs/32019232007/job/95355230412
Expected commits have been pushed: https://github.com/Alfresco/acs-packaging/commit/f1bd0766c48c1419901f7b2c045496133698821e, https://github.com/Alfresco/acs-packaging/commit/b9987b9dd808c4281e62870b8cb734e7ab8d933b.

The changes are due to a failed release in acs-packaging: https://github.com/Alfresco/acs-packaging/actions/runs/31701622399/job/94458041603