### PR TITLE
Add versions-set-args input to maven-release-slim

### DIFF
--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -19,6 +19,10 @@ inputs:
     required: false
     description: Additional Maven arguments for release. Defaults to "-DskipTests".
     default: -DskipTests
+  versions-set-args:
+    required: false
+    description: Additional arguments passed to the versions:set commands.
+    default: ''
   create-tag:
     required: false
     description: Boolean if should create tag.
@@ -32,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: "Set release version to ${{ inputs.release-version }}"
-      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false ${{ inputs.versions-set-args }}
       shell: bash
 
     - name: "Deploy release version ${{ inputs.release-version }}"
@@ -56,7 +60,7 @@ runs:
       shell: bash
 
     - name: "Set next development version to ${{ inputs.development-version }}"
-      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
+      run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false ${{ inputs.versions-set-args }}
       shell: bash
 
     - name: "Commit next development version ${{ inputs.development-version }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1947,6 +1947,7 @@ A lightweight Maven release action that sets the release version, deploys the ar
           development-version: 1.2.4-SNAPSHOT
           release-profile: release  # optional, default: release
           maven-args: -DskipTests  # optional, default: -DskipTests
+          versions-set-args: -DprocessAllModules=true  # optional, additional arguments for the versions:set commands
           create-tag: 'true'  # optional, default: 'true'
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
 ```


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): none
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Adds a new optional `versions-set-args` input to the `maven-release-slim` action, letting callers pass additional arguments (e.g. `-DprocessAllModules=true`) to the `versions:set` commands used for setting the release and next development versions.