### PR TITLE
OPSEXP-4294 fix(env-load-from-yaml): treat values as literals and tolerate missing files

### DIFF
--- a/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
+++ b/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-# A missing input file is a no-op: callers rely on being able to point this
-# at an optional per-environment override file.
-[ -f "$YML_PATH" ] || exit 0
+if [ ! -f "$YML_PATH" ]; then
+  echo "::warning::$YML_PATH not found, skipping"
+  exit 0
+fi
 
-# Capture yq output before looping so a yq failure aborts the script
-# instead of being swallowed by process substitution.
 entries="$(yq '.env.global[]' "$YML_PATH")"
 
 while IFS= read -r ENVVAR; do
@@ -20,8 +19,7 @@ while IFS= read -r ENVVAR; do
   # Values are taken verbatim (quotes, spaces, JSON kept byte-for-byte) with
   # only $VAR/${VAR} expansion applied, via envsubst rather than eval, so a
   # value can never trigger shell word-splitting or command execution.
-  value="$(printf '%s' "$rhs" | envsubst; printf x)"
-  value="${value%x}"
+  value="$(printf '%s' "$rhs" | envsubst)"
   export "$name=$value"
   if [[ "$value" == *$'\n'* ]]; then
     delimiter="EOF_$(openssl rand -hex 8)"

--- a/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
+++ b/.github/actions/env-load-from-yaml/env-load-from-yaml.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
-# Capture yq output before looping so a yq failure/missing file aborts the
-# script instead of being swallowed by process substitution.
+# A missing input file is a no-op: callers rely on being able to point this
+# at an optional per-environment override file.
+[ -f "$YML_PATH" ] || exit 0
+
+# Capture yq output before looping so a yq failure aborts the script
+# instead of being swallowed by process substitution.
 entries="$(yq '.env.global[]' "$YML_PATH")"
 
 while IFS= read -r ENVVAR; do
@@ -13,8 +17,11 @@ while IFS= read -r ENVVAR; do
   fi
   name="${ENVVAR%%=*}"
   rhs="${ENVVAR#*=}"
-  eval "value=\"$rhs\""
-  # shellcheck disable=SC2154 # value is assigned above via eval
+  # Values are taken verbatim (quotes, spaces, JSON kept byte-for-byte) with
+  # only $VAR/${VAR} expansion applied, via envsubst rather than eval, so a
+  # value can never trigger shell word-splitting or command execution.
+  value="$(printf '%s' "$rhs" | envsubst; printf x)"
+  value="${value%x}"
   export "$name=$value"
   if [[ "$value" == *$'\n'* ]]; then
     delimiter="EOF_$(openssl rand -hex 8)"

--- a/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
+++ b/.github/actions/env-load-from-yaml/tests/env-load-from-yaml.bats
@@ -32,11 +32,56 @@ setup() {
     grep -qx 'VAR2=expanded-value' "$GITHUB_ENV"
 }
 
-@test "missing yaml file aborts with non-zero and writes nothing" {
+@test "missing yaml file is a no-op" {
     export YML_PATH="$DIR/does-not-exist.yml"
     run env-load-from-yaml.sh
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 0 ]
     [ ! -s "$GITHUB_ENV" ]
+}
+
+@test "quoted multi-word value round-trips with quotes preserved" {
+    export YML_PATH="$DIR/literal.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'QUOTED_MULTIWORD="--batch-mode --quiet -U"' "$GITHUB_ENV"
+}
+
+@test "JSON list value round-trips with quotes and brackets preserved" {
+    export YML_PATH="$DIR/literal.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'JSON_LIST=[ "x", "y" ]' "$GITHUB_ENV"
+}
+
+@test "JSON map value round-trips with quotes and braces preserved" {
+    export YML_PATH="$DIR/literal.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'JSON_MAP={"k":"v"}' "$GITHUB_ENV"
+}
+
+@test "\$VAR expansion still works inside an otherwise literal JSON value" {
+    export YML_PATH="$DIR/literal.yml"
+    export ANOTHER_VAR="expanded-value"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'EXPANDED_IN_JSON_MAP={"k":"expanded-value"}' "$GITHUB_ENV"
+}
+
+@test "\$(...) subshell syntax is kept literal, never executed" {
+    export YML_PATH="$DIR/literal.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'SUBSHELL_ATTEMPT=$(echo pwned)' "$GITHUB_ENV"
+    ! grep -q '^pwned$' "$GITHUB_ENV"
+}
+
+@test "backtick command substitution syntax is kept literal, never executed" {
+    export YML_PATH="$DIR/literal.yml"
+    run env-load-from-yaml.sh
+    [ "$status" -eq 0 ]
+    grep -qxF 'BACKTICK_ATTEMPT=`echo pwned`' "$GITHUB_ENV"
+    ! grep -q '^pwned$' "$GITHUB_ENV"
 }
 
 @test "multiline value uses heredoc and round-trips" {

--- a/.github/actions/env-load-from-yaml/tests/literal.yml
+++ b/.github/actions/env-load-from-yaml/tests/literal.yml
@@ -1,0 +1,8 @@
+env:
+  global:
+    - QUOTED_MULTIWORD="--batch-mode --quiet -U"
+    - JSON_LIST=[ "x", "y" ]
+    - JSON_MAP={"k":"v"}
+    - SUBSHELL_ATTEMPT=$(echo pwned)
+    - BACKTICK_ATTEMPT=`echo pwned`
+    - EXPANDED_IN_JSON_MAP={"k":"$ANOTHER_VAR"}


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): OPSEXP-4294
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: https://github.com/Alfresco/terraform-alfresco-pipeline/pull/1992

### Description

The `env-load-from-yaml` rewrite in v18.19.1 (#1475) parsed each value with `eval "value=\"$rhs\""`, which re-split quoted multi-word values on spaces (breaking things like `MAVEN_CLI_OPTS="--batch-mode --quiet -U"`, whose second word then ran as a command), stripped quotes out of JSON values, and could even execute backtick/`$(...)` sequences embedded in a value since both are expanded inside double quotes by bash. It also turned a missing `yml_path` into a hard failure, breaking callers that point it at an optional per-environment override file.

This replaces the `eval`-based parsing with `envsubst`, so a value is taken verbatim from after `=` to end of line (quotes, spaces, JSON braces/brackets preserved byte-for-byte) with only `$VAR`/`${VAR}` expansion applied, and makes a missing `yml_path` a no-op (with a `::warning::` logged) instead of an error.

Adds bats coverage for literal quoting, JSON round-tripping, `$VAR` expansion inside an otherwise-literal value, the missing-file no-op, and regression tests proving `$(...)`/backtick payloads are written literally and never executed.