### PR TITLE
ACS-12085 maven-release-slim: add post-version-command input

### DIFF
--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -27,12 +27,21 @@ inputs:
     required: false
     description: Prefix used by bot for commit message. Defaults to "[skip ci]".
     default: '[skip ci]'
+  post-version-command:
+    required: false
+    description: Optional custom command to run after setting the release version and before deploying (e.g. "mvn generate-sources").
+    default: ''
 
 runs:
   using: composite
   steps:
     - name: "Set release version to ${{ inputs.release-version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false
+      shell: bash
+
+    - name: "Run post-version command"
+      if: inputs.post-version-command != ''
+      run: ${{ inputs.post-version-command }}
       shell: bash
 
     - name: "Deploy release version ${{ inputs.release-version }}"

--- a/.github/actions/maven-release-slim/action.yml
+++ b/.github/actions/maven-release-slim/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: '[skip ci]'
   post-version-command:
     required: false
-    description: Optional custom command to run after setting the release version and before deploying (e.g. "mvn generate-sources").
+    description: Optional custom command to run after each "versions:set" call, i.e. after setting the release version and after setting the next development version (e.g. "mvn generate-sources").
     default: ''
 
 runs:
@@ -39,7 +39,7 @@ runs:
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.release-version }}" -DgenerateBackupPoms=false
       shell: bash
 
-    - name: "Run post-version command"
+    - name: "Run post-version command after release version"
       if: inputs.post-version-command != ''
       run: ${{ inputs.post-version-command }}
       shell: bash
@@ -66,6 +66,11 @@ runs:
 
     - name: "Set next development version to ${{ inputs.development-version }}"
       run: mvn -B -ntp versions:set -DnewVersion="${{ inputs.development-version }}" -DgenerateBackupPoms=false
+      shell: bash
+
+    - name: "Run post-version command after development version"
+      if: inputs.post-version-command != ''
+      run: ${{ inputs.post-version-command }}
       shell: bash
 
     - name: "Commit next development version ${{ inputs.development-version }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1949,7 +1949,7 @@ A lightweight Maven release action that sets the release version, deploys the ar
           maven-args: -DskipTests  # optional, default: -DskipTests
           create-tag: 'true'  # optional, default: 'true'
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
-          post-version-command: 'mvn generate-sources'  # optional, runs after setting the release version and before deploying
+          post-version-command: 'mvn generate-sources'  # optional, runs after each "versions:set" call (release version and next development version)
 ```
 
 Java and Maven should be set up before invoking the action. The provided `token` must have write access to the repository contents to push the release/development version commits and (if enabled) the release tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1949,6 +1949,7 @@ A lightweight Maven release action that sets the release version, deploys the ar
           maven-args: -DskipTests  # optional, default: -DskipTests
           create-tag: 'true'  # optional, default: 'true'
           commit-message-prefix: '[skip ci]'  # optional, default: '[skip ci]'
+          post-version-command: 'mvn generate-sources'  # optional, runs after setting the release version and before deploying
 ```
 
 Java and Maven should be set up before invoking the action. The provided `token` must have write access to the repository contents to push the release/development version commits and (if enabled) the release tag.


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): ACS-12085
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Adds an optional `post-version-command` input to `maven-release-slim`, letting callers inject a custom command (e.g. `mvn generate-sources`) that runs after each `versions:set` call — once after the release version is set (before the `mvn deploy` step) and once after the next development version is set (before its commit step). Defaults to empty, so existing callers are unaffected.