### PR TITLE
AAE-50050 Restore commit message variable expansion in git-commit-changes

### DIFF
--- a/.github/actions/git-commit-changes/action.yml
+++ b/.github/actions/git-commit-changes/action.yml
@@ -44,7 +44,6 @@ runs:
         GIT_COMMIT_USERNAME: ${{ inputs.username }}
         GIT_COMMIT_EMAIL: ${{ inputs.email }}
         GIT_COMMIT_ADD_OPTIONS: ${{ inputs.add-options }}
-        GIT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
         GIT_COMMIT_OPTIONS: ${{ inputs.commit-options }}
         GIT_COMMIT_REPO_DIR: ${{ inputs.repository-directory }}
         GIT_COMMIT_SKIP_IF_NO_CHANGES: ${{ inputs.skip-if-no-changes }}
@@ -60,11 +59,10 @@ runs:
         git add $GIT_COMMIT_ADD_OPTIONS
         git status
         git --no-pager diff --cached
-        GIT_COMMIT_MESSAGE="$(printf '%s' "$GIT_COMMIT_MESSAGE" | envsubst)"
         if [ "$GIT_COMMIT_SKIP_IF_NO_CHANGES" = "true" ]; then
           # shellcheck disable=SC2086
-          git diff-index --quiet HEAD || git commit -m "$GIT_COMMIT_MESSAGE" $GIT_COMMIT_OPTIONS
+          git diff-index --quiet HEAD || git commit -m "${{ inputs.commit-message }}" $GIT_COMMIT_OPTIONS
         else
           # shellcheck disable=SC2086
-          git commit -m "$GIT_COMMIT_MESSAGE" $GIT_COMMIT_OPTIONS
+          git commit -m "${{ inputs.commit-message }}" $GIT_COMMIT_OPTIONS
         fi

--- a/.github/actions/git-commit-changes/action.yml
+++ b/.github/actions/git-commit-changes/action.yml
@@ -44,6 +44,7 @@ runs:
         GIT_COMMIT_USERNAME: ${{ inputs.username }}
         GIT_COMMIT_EMAIL: ${{ inputs.email }}
         GIT_COMMIT_ADD_OPTIONS: ${{ inputs.add-options }}
+        GIT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
         GIT_COMMIT_OPTIONS: ${{ inputs.commit-options }}
         GIT_COMMIT_REPO_DIR: ${{ inputs.repository-directory }}
         GIT_COMMIT_SKIP_IF_NO_CHANGES: ${{ inputs.skip-if-no-changes }}
@@ -59,10 +60,11 @@ runs:
         git add $GIT_COMMIT_ADD_OPTIONS
         git status
         git --no-pager diff --cached
+        GIT_COMMIT_MESSAGE="$(printf '%s' "$GIT_COMMIT_MESSAGE" | envsubst)"
         if [ "$GIT_COMMIT_SKIP_IF_NO_CHANGES" = "true" ]; then
           # shellcheck disable=SC2086
-          git diff-index --quiet HEAD || git commit -m "${{ inputs.commit-message }}" $GIT_COMMIT_OPTIONS
+          git diff-index --quiet HEAD || git commit -m "$GIT_COMMIT_MESSAGE" $GIT_COMMIT_OPTIONS
         else
           # shellcheck disable=SC2086
-          git commit -m "${{ inputs.commit-message }}" $GIT_COMMIT_OPTIONS
+          git commit -m "$GIT_COMMIT_MESSAGE" $GIT_COMMIT_OPTIONS
         fi

--- a/.github/actions/git-commit-changes/action.yml
+++ b/.github/actions/git-commit-changes/action.yml
@@ -60,6 +60,7 @@ runs:
         git add $GIT_COMMIT_ADD_OPTIONS
         git status
         git --no-pager diff --cached
+        GIT_COMMIT_MESSAGE="$(printf '%s' "$GIT_COMMIT_MESSAGE" | envsubst)"
         if [ "$GIT_COMMIT_SKIP_IF_NO_CHANGES" = "true" ]; then
           # shellcheck disable=SC2086
           git diff-index --quiet HEAD || git commit -m "$GIT_COMMIT_MESSAGE" $GIT_COMMIT_OPTIONS


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): https://hyland.atlassian.net/browse/AAE-50050
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description
<img width="343" height="252" alt="image" src="https://github.com/user-attachments/assets/d7ddc373-5018-4397-9be5-9e9a642a6c32" />
