### PR TITLE
ACS-12615 Add new dependabot workflow run automation action

### DIFF
--- a/.github/actions/dependabot-workflow-run-automation/action.yml
+++ b/.github/actions/dependabot-workflow-run-automation/action.yml
@@ -51,20 +51,21 @@ runs:
 
     - name: Generate GitHub App token
       id: app-token
-      if: >-
-        ${{
-          steps.pull-request.outputs.number != '' &&
-          github.event.workflow_run.conclusion == 'success'
-        }}
+      if: steps.pull-request.outputs.number != ''
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ inputs.app-client-id }}
         private-key: ${{ inputs.app-private-key }}
+        permission-actions: write
         permission-contents: write
         permission-pull-requests: write
 
     - name: Approve and enable auto-merge
-      if: steps.app-token.outcome == 'success'
+      if: >-
+        ${{
+          steps.app-token.outcome == 'success' &&
+          github.event.workflow_run.conclusion == 'success'
+        }}
       shell: bash
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -89,7 +90,7 @@ runs:
         }}
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
         GH_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.event.workflow_run.id }}
       run: gh run rerun "$RUN_ID" --failed
@@ -105,7 +106,7 @@ runs:
         }}
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
         GH_REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pull-request.outputs.number }}
         MAINTAINERS_TEAM: ${{ inputs.maintainers-team }}

--- a/.github/actions/dependabot-workflow-run-automation/action.yml
+++ b/.github/actions/dependabot-workflow-run-automation/action.yml
@@ -24,12 +24,36 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve current Dependabot pull request
+      id: pull-request
+      if: >-
+        ${{
+          github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.actor.login == 'dependabot[bot]'
+        }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+      run: |
+        while read -r PR_NUMBER; do
+          PR="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+          if jq -e --arg head_sha "$HEAD_SHA" \
+            '.state == "open" and .user.login == "dependabot[bot]" and .head.sha == $head_sha' \
+            <<< "$PR" > /dev/null; then
+            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        done < <(jq -r '.[]?.number' <<< "$PULL_REQUESTS")
+        echo "No open Dependabot PR at ${HEAD_SHA} found in the workflow run payload."
+
     - name: Generate GitHub App token
       id: app-token
       if: >-
         ${{
-          github.event.workflow_run.event == 'pull_request' &&
-          github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+          steps.pull-request.outputs.number != '' &&
           github.event.workflow_run.conclusion == 'success'
         }}
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -45,18 +69,14 @@ runs:
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
         GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.pull-request.outputs.number }}
         HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         MERGE_METHOD: ${{ inputs.merge-method }}
       run: |
-        PR_NUMBER="$(gh api \
-          "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
-          --jq '.[0].number')"
-        if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
-          echo "No associated PR found for ${HEAD_SHA}; nothing to do."
-          exit 0
-        fi
-        gh pr review "$PR_NUMBER" --approve
-        gh pr merge "$PR_NUMBER" --auto "--${MERGE_METHOD}"
+        gh api --method POST "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" \
+          -f event=APPROVE \
+          -f commit_id="$HEAD_SHA"
+        gh pr merge "$PR_NUMBER" --auto "--${MERGE_METHOD}" --match-head-commit "$HEAD_SHA"
 
     - name: Re-run failed jobs
       if: >-
@@ -64,7 +84,8 @@ runs:
           github.event.workflow_run.event == 'pull_request' &&
           github.event.workflow_run.actor.login == 'dependabot[bot]' &&
           github.event.workflow_run.conclusion == 'failure' &&
-          github.event.workflow_run.run_attempt < fromJSON(inputs.max-attempts)
+          github.event.workflow_run.run_attempt < fromJSON(inputs.max-attempts) &&
+          steps.pull-request.outputs.number != ''
         }}
       shell: bash
       env:
@@ -79,23 +100,17 @@ runs:
           github.event.workflow_run.event == 'pull_request' &&
           github.event.workflow_run.actor.login == 'dependabot[bot]' &&
           github.event.workflow_run.conclusion == 'failure' &&
-          github.event.workflow_run.run_attempt >= fromJSON(inputs.max-attempts)
+          github.event.workflow_run.run_attempt >= fromJSON(inputs.max-attempts) &&
+          steps.pull-request.outputs.number != ''
         }}
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
-        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        PR_NUMBER: ${{ steps.pull-request.outputs.number }}
         MAINTAINERS_TEAM: ${{ inputs.maintainers-team }}
         RUN_URL: ${{ github.event.workflow_run.html_url }}
       run: |
-        PR_NUMBER="$(gh api \
-          "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
-          --jq '.[0].number')"
-        if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
-          echo "No associated PR found for ${HEAD_SHA}; skipping notification."
-          exit 0
-        fi
         gh pr comment "$PR_NUMBER" --body \
           ":red_circle: CI **re-run still failing** for this Dependabot update.
         cc @${MAINTAINERS_TEAM} - automatic retries did not resolve the failure; manual investigation is needed.

--- a/.github/actions/dependabot-workflow-run-automation/action.yml
+++ b/.github/actions/dependabot-workflow-run-automation/action.yml
@@ -1,0 +1,102 @@
+name: Dependabot workflow run automation
+description: Approve and auto-merge successful Dependabot PRs, retry failed jobs, and notify maintainers of persistent failures
+
+inputs:
+  app-client-id:
+    description: GitHub App client ID used to approve and enable auto-merge
+    required: true
+  app-private-key:
+    description: GitHub App private key used to approve and enable auto-merge
+    required: true
+  maintainers-team:
+    description: Team to mention when CI still fails after all retry attempts
+    required: false
+    default: Alfresco/alfresco-dependency-maintainers
+  max-attempts:
+    description: Maximum workflow run attempt before maintainers are notified
+    required: false
+    default: '2'
+  merge-method:
+    description: Pull request merge method (merge, rebase, or squash)
+    required: false
+    default: squash
+
+runs:
+  using: composite
+  steps:
+    - name: Generate GitHub App token
+      id: app-token
+      if: >-
+        ${{
+          github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+          github.event.workflow_run.conclusion == 'success'
+        }}
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ inputs.app-client-id }}
+        private-key: ${{ inputs.app-private-key }}
+        permission-contents: write
+        permission-pull-requests: write
+
+    - name: Approve and enable auto-merge
+      if: steps.app-token.outcome == 'success'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        GH_REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: |
+        PR_NUMBER="$(gh api \
+          "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
+          --jq '.[0].number')"
+        if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+          echo "No associated PR found for ${HEAD_SHA}; nothing to do."
+          exit 0
+        fi
+        gh pr review "$PR_NUMBER" --approve
+        gh pr merge "$PR_NUMBER" --auto "--${MERGE_METHOD}"
+
+    - name: Re-run failed jobs
+      if: >-
+        ${{
+          github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+          github.event.workflow_run.conclusion == 'failure' &&
+          github.event.workflow_run.run_attempt < fromJSON(inputs.max-attempts)
+        }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.event.workflow_run.id }}
+      run: gh run rerun "$RUN_ID" --failed
+
+    - name: Notify maintainers of persistent failure
+      if: >-
+        ${{
+          github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+          github.event.workflow_run.conclusion == 'failure' &&
+          github.event.workflow_run.run_attempt >= fromJSON(inputs.max-attempts)
+        }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        MAINTAINERS_TEAM: ${{ inputs.maintainers-team }}
+        RUN_URL: ${{ github.event.workflow_run.html_url }}
+      run: |
+        PR_NUMBER="$(gh api \
+          "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
+          --jq '.[0].number')"
+        if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+          echo "No associated PR found for ${HEAD_SHA}; skipping notification."
+          exit 0
+        fi
+        gh pr comment "$PR_NUMBER" --body \
+          ":red_circle: CI **re-run still failing** for this Dependabot update.
+        cc @${MAINTAINERS_TEAM} - automatic retries did not resolve the failure; manual investigation is needed.
+        [View run](${RUN_URL})"

--- a/docs/README.md
+++ b/docs/README.md
@@ -572,9 +572,7 @@ on:
       - "dependabot/maven/alfresco-enterprise-repo-**"
 
 permissions:
-  actions: write
-  contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   automate:
@@ -592,10 +590,10 @@ jobs:
 Use a `workflow_run.branches` filter that selects only the intended Dependabot group branches. The action also checks
 that the completed run was triggered by a pull request and that its actor is `dependabot[bot]`. Before acting, it
 resolves the PR from the workflow run payload and verifies that the PR is open, authored by Dependabot, and still points
-at the completed run's head SHA. It uses the workflow's `GITHUB_TOKEN` to re-run jobs and comment, and creates a GitHub
-App token to approve the PR and enable auto-merge because the default token cannot approve a pull request. The GitHub
-App must have write access to repository contents and pull requests. The merge method must be `merge`, `rebase`, or
-`squash`.
+at the completed run's head SHA. It uses the workflow's `GITHUB_TOKEN` only to read pull request details. It creates a
+GitHub App token to re-run jobs, comment, approve the PR, and enable auto-merge because the default token cannot approve
+a pull request. The GitHub App must have write access to actions, repository contents, and pull requests. The merge
+method must be `merge`, `rebase`, or `squash`.
 
 ### dependabot-missing-actions-check
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Here follows the list of GitHub Actions topics available in the current document
   - [calculate-next-internal-version](#calculate-next-internal-version)
   - [check-pr-description](#check-pr-description)
   - [configure-git-author](#configure-git-author)
+  - [dependabot-workflow-run-automation](#dependabot-workflow-run-automation)
   - [dependabot-missing-actions-check](#dependabot-missing-actions-check)
   - [dbp-charts](#dbp-charts)
   - [dispatch-resume-workflow](#dispatch-resume-workflow)
@@ -554,6 +555,45 @@ Configures the git username and email to associate commits with the provided ide
 ```
 
 The two vars in the previous snippet are [workflow configuration variables](https://github.blog/changelog/2023-01-10-github-actions-support-for-configuration-variables-in-workflows/) that can be created at organization level and shared across different repositories.
+
+### dependabot-workflow-run-automation
+
+Approves and enables auto-merge for a Dependabot PR after successful CI, re-runs failed jobs up to a configured
+attempt limit, and mentions a maintainers team when the final attempt still fails.
+
+```yaml
+name: Dependabot group automation
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches:
+      - "dependabot/maven/alfresco-enterprise-repo-**"
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  automate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Alfresco/alfresco-build-tools/.github/actions/dependabot-workflow-run-automation@v18.24.1
+        with:
+          app-client-id: ${{ vars.GH_APP_ENGINEERING_CONTRIB_CLIENT_ID }}
+          app-private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
+          maintainers-team: Alfresco/alfresco-dependency-maintainers # optional, default shown
+          max-attempts: "2" # optional, default: 2
+          merge-method: squash # optional, default: squash
+```
+
+Use a `workflow_run.branches` filter that selects only the intended Dependabot group branches. The action also checks
+that the completed run was triggered by a pull request and that its actor is `dependabot[bot]`. It uses the workflow's
+`GITHUB_TOKEN` to re-run jobs and comment, and creates a GitHub App token to approve the PR and enable auto-merge
+because the default token cannot approve a pull request. The GitHub App must have write access to repository contents
+and pull requests. The merge method must be `merge`, `rebase`, or `squash`.
 
 ### dependabot-missing-actions-check
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -573,7 +573,7 @@ on:
 
 permissions:
   actions: write
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -590,10 +590,12 @@ jobs:
 ```
 
 Use a `workflow_run.branches` filter that selects only the intended Dependabot group branches. The action also checks
-that the completed run was triggered by a pull request and that its actor is `dependabot[bot]`. It uses the workflow's
-`GITHUB_TOKEN` to re-run jobs and comment, and creates a GitHub App token to approve the PR and enable auto-merge
-because the default token cannot approve a pull request. The GitHub App must have write access to repository contents
-and pull requests. The merge method must be `merge`, `rebase`, or `squash`.
+that the completed run was triggered by a pull request and that its actor is `dependabot[bot]`. Before acting, it
+resolves the PR from the workflow run payload and verifies that the PR is open, authored by Dependabot, and still points
+at the completed run's head SHA. It uses the workflow's `GITHUB_TOKEN` to re-run jobs and comment, and creates a GitHub
+App token to approve the PR and enable auto-merge because the default token cannot approve a pull request. The GitHub
+App must have write access to repository contents and pull requests. The merge method must be `merge`, `rebase`, or
+`squash`.
 
 ### dependabot-missing-actions-check
 


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): ACS-12615
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: N/A - not externally tested

### Description

Adds a reusable composite action that automates Dependabot pull requests after CI completes.

The action:

- Approves successful Dependabot PRs and enables auto-merge.
- Re-runs failed jobs up to a configurable attempt limit.
- Notifies the dependency maintainers team when failures persist.
- Uses the workflow token only for read access and a GitHub App token for privileged operations.
- Verifies the PR author, status, branch SHA, and workflow event before taking action.
- Documents configuration, permissions, and usage in the README.
