### PR TITLE
OPSEXP-4351 Speed up free-hosted-runner-disk-space folder removal

### DIFF
--- a/.github/actions/free-hosted-runner-disk-space/action.yml
+++ b/.github/actions/free-hosted-runner-disk-space/action.yml
@@ -38,7 +38,7 @@ inputs:
     default: ''
     required: false
   diagnose-top-offenders-enabled:
-    description: Runs diagnostic steps to list top disk space offenders before and after cleanup
+    description: Runs diagnostic steps to list top disk space offenders before and after cleanup, and reports the size of each folder before it is removed
     required: false
     default: 'false'
 
@@ -74,7 +74,7 @@ runs:
         if [[ ${{ inputs.remove-dotnet }} == 'true' && -d $DOTNET_ROOT ]]; then
           echo "Removing .NET runtime and libraries..."
           start_time=$(date +%s)
-          du -sh $DOTNET_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $DOTNET_ROOT
           sudo rm -rf $DOTNET_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -85,7 +85,7 @@ runs:
         if [[ ${{ inputs.remove-android }} == 'true' && -d $ANDROID_ROOT ]]; then
           echo "Removing Android SDKs and Tools..."
           start_time=$(date +%s)
-          du -sh $ANDROID_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $ANDROID_ROOT
           sudo rm -rf $ANDROID_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -96,7 +96,7 @@ runs:
         if [[ ${{ inputs.remove-haskell }} == 'true' && -d $HASKELL_ROOT ]]; then
           echo "Removing GHC (Haskell) artifacts..."
           start_time=$(date +%s)
-          du -sh $HASKELL_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $HASKELL_ROOT
           sudo rm -rf $HASKELL_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -107,7 +107,7 @@ runs:
         if [[ ${{ inputs.remove-codeql }} == 'true' && -d $CODEQL_ROOT ]]; then
           echo "Removing CodeQL Action Bundles..."
           start_time=$(date +%s)
-          du -sh $CODEQL_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $CODEQL_ROOT
           sudo rm -rf $CODEQL_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -118,7 +118,7 @@ runs:
         if [[ ${{ inputs.remove-tools-cache }} == 'true' && -d $AGENT_TOOLSDIRECTORY ]]; then
           echo "Removing tools and dependencies cache..."
           start_time=$(date +%s)
-          du -sh $AGENT_TOOLSDIRECTORY
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $AGENT_TOOLSDIRECTORY
           sudo rm -rf $AGENT_TOOLSDIRECTORY/*
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -129,7 +129,7 @@ runs:
         if [[ ${{ inputs.remove-swift }} == 'true' && -d $SWIFT_ROOT ]]; then
           echo "Removing Swift toolchain and libraries..."
           start_time=$(date +%s)
-          du -sh $SWIFT_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $SWIFT_ROOT
           sudo rm -rf $SWIFT_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -140,7 +140,7 @@ runs:
         if [[ ${{ inputs.remove-powershell }} == 'true' && -d $POWERSHELL_ROOT ]]; then
           echo "Removing PowerShell Core installation..."
           start_time=$(date +%s)
-          du -sh $POWERSHELL_ROOT
+          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $POWERSHELL_ROOT
           sudo rm -rf $POWERSHELL_ROOT
           end_time=$(date +%s)
           echo "Removed in $((end_time - start_time)) seconds"
@@ -163,7 +163,7 @@ runs:
 
           for item in $to_remove; do
             echo "Removing $item ..."
-            du -sh "$item"
+            [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh "$item"
             sudo rm -rf "$item"
           done
 

--- a/.github/actions/free-hosted-runner-disk-space/action.yml
+++ b/.github/actions/free-hosted-runner-disk-space/action.yml
@@ -73,6 +73,7 @@ runs:
       run: |
         diagnose="${{ inputs.diagnose-top-offenders-enabled }}"
         overall_start=$(date +%s)
+        pids=()
 
         remove_in_background() {
           local label="$1" path="$2"
@@ -80,6 +81,7 @@ runs:
             echo "Removing $label ($path) in the background..."
             [[ "$diagnose" == 'true' ]] && du -sh "$path"
             sudo rm -rf "$path" &
+            pids+=("$!")
           else
             echo "$path not found, skipping $label"
           fi
@@ -92,17 +94,12 @@ runs:
         [[ ${{ inputs.remove-swift }} == 'true' ]] && remove_in_background "Swift toolchain and libraries" "$SWIFT_ROOT"
         [[ ${{ inputs.remove-powershell }} == 'true' ]] && remove_in_background "PowerShell Core installation" "$POWERSHELL_ROOT"
 
-        if [[ ${{ inputs.remove-tools-cache }} == 'true' && -d $AGENT_TOOLSDIRECTORY ]]; then
-          echo "Removing tools and dependencies cache ($AGENT_TOOLSDIRECTORY) in the background..."
-          [[ "$diagnose" == 'true' ]] && du -sh $AGENT_TOOLSDIRECTORY
-          sudo rm -rf $AGENT_TOOLSDIRECTORY/* &
-        else
-          echo "$AGENT_TOOLSDIRECTORY not found, skipping tools and dependencies cache"
-        fi
+        [[ ${{ inputs.remove-tools-cache }} == 'true' ]] && remove_in_background "tools and dependencies cache" "$AGENT_TOOLSDIRECTORY"
 
         if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
           echo "Removing cached Docker images in the background..."
           sudo docker image prune --all --force &
+          pids+=("$!")
         fi
 
         to_remove="${{ inputs.remove-paths }}"
@@ -111,12 +108,22 @@ runs:
             echo "Removing $item in the background..."
             [[ "$diagnose" == 'true' ]] && du -sh "$item"
             sudo rm -rf "$item" &
+            pids+=("$!")
           done
         fi
 
-        wait
+        failed=0
+        for pid in "${pids[@]}"; do
+          wait "$pid" || failed=1
+        done
+
         overall_end=$(date +%s)
         echo "Done removing unwanted software in $((overall_end - overall_start)) seconds."
+
+        if [[ "$failed" -eq 1 ]]; then
+          echo "One or more removal commands failed." >&2
+          exit 1
+        fi
       shell: bash
 
     - name: Run optional diagnostic of top offenders after cleanup

--- a/.github/actions/free-hosted-runner-disk-space/action.yml
+++ b/.github/actions/free-hosted-runner-disk-space/action.yml
@@ -71,107 +71,52 @@ runs:
         SWIFT_ROOT: /usr/share/swift
         POWERSHELL_ROOT: /usr/local/share/powershell
       run: |
-        if [[ ${{ inputs.remove-dotnet }} == 'true' && -d $DOTNET_ROOT ]]; then
-          echo "Removing .NET runtime and libraries..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $DOTNET_ROOT
-          sudo rm -rf $DOTNET_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$DOTNET_ROOT not found"
-        fi
+        diagnose="${{ inputs.diagnose-top-offenders-enabled }}"
+        overall_start=$(date +%s)
 
-        if [[ ${{ inputs.remove-android }} == 'true' && -d $ANDROID_ROOT ]]; then
-          echo "Removing Android SDKs and Tools..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $ANDROID_ROOT
-          sudo rm -rf $ANDROID_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$ANDROID_ROOT not found"
-        fi
+        remove_in_background() {
+          local label="$1" path="$2"
+          if [[ -d "$path" ]]; then
+            echo "Removing $label ($path) in the background..."
+            [[ "$diagnose" == 'true' ]] && du -sh "$path"
+            sudo rm -rf "$path" &
+          else
+            echo "$path not found, skipping $label"
+          fi
+        }
 
-        if [[ ${{ inputs.remove-haskell }} == 'true' && -d $HASKELL_ROOT ]]; then
-          echo "Removing GHC (Haskell) artifacts..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $HASKELL_ROOT
-          sudo rm -rf $HASKELL_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$HASKELL_ROOT not found"
-        fi
-
-        if [[ ${{ inputs.remove-codeql }} == 'true' && -d $CODEQL_ROOT ]]; then
-          echo "Removing CodeQL Action Bundles..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $CODEQL_ROOT
-          sudo rm -rf $CODEQL_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$CODEQL_ROOT not found"
-        fi
+        [[ ${{ inputs.remove-dotnet }} == 'true' ]] && remove_in_background ".NET runtime and libraries" "$DOTNET_ROOT"
+        [[ ${{ inputs.remove-android }} == 'true' ]] && remove_in_background "Android SDKs and Tools" "$ANDROID_ROOT"
+        [[ ${{ inputs.remove-haskell }} == 'true' ]] && remove_in_background "GHC (Haskell) artifacts" "$HASKELL_ROOT"
+        [[ ${{ inputs.remove-codeql }} == 'true' ]] && remove_in_background "CodeQL Action Bundles" "$CODEQL_ROOT"
+        [[ ${{ inputs.remove-swift }} == 'true' ]] && remove_in_background "Swift toolchain and libraries" "$SWIFT_ROOT"
+        [[ ${{ inputs.remove-powershell }} == 'true' ]] && remove_in_background "PowerShell Core installation" "$POWERSHELL_ROOT"
 
         if [[ ${{ inputs.remove-tools-cache }} == 'true' && -d $AGENT_TOOLSDIRECTORY ]]; then
-          echo "Removing tools and dependencies cache..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $AGENT_TOOLSDIRECTORY
-          sudo rm -rf $AGENT_TOOLSDIRECTORY/*
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
+          echo "Removing tools and dependencies cache ($AGENT_TOOLSDIRECTORY) in the background..."
+          [[ "$diagnose" == 'true' ]] && du -sh $AGENT_TOOLSDIRECTORY
+          sudo rm -rf $AGENT_TOOLSDIRECTORY/* &
         else
-          echo "$AGENT_TOOLSDIRECTORY not found"
-        fi
-
-        if [[ ${{ inputs.remove-swift }} == 'true' && -d $SWIFT_ROOT ]]; then
-          echo "Removing Swift toolchain and libraries..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $SWIFT_ROOT
-          sudo rm -rf $SWIFT_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$SWIFT_ROOT not found"
-        fi
-
-        if [[ ${{ inputs.remove-powershell }} == 'true' && -d $POWERSHELL_ROOT ]]; then
-          echo "Removing PowerShell Core installation..."
-          start_time=$(date +%s)
-          [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh $POWERSHELL_ROOT
-          sudo rm -rf $POWERSHELL_ROOT
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
-        else
-          echo "$POWERSHELL_ROOT not found"
+          echo "$AGENT_TOOLSDIRECTORY not found, skipping tools and dependencies cache"
         fi
 
         if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
-          echo "Removing cached Docker images..."
-          start_time=$(date +%s)
-          sudo docker image prune --all --force
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
+          echo "Removing cached Docker images in the background..."
+          sudo docker image prune --all --force &
         fi
 
         to_remove="${{ inputs.remove-paths }}"
         if [[ -n "$to_remove" ]]; then
-          echo "Removing additional files/folders..."
-          start_time=$(date +%s)
-
           for item in $to_remove; do
-            echo "Removing $item ..."
-            [[ ${{ inputs.diagnose-top-offenders-enabled }} == 'true' ]] && du -sh "$item"
-            sudo rm -rf "$item"
+            echo "Removing $item in the background..."
+            [[ "$diagnose" == 'true' ]] && du -sh "$item"
+            sudo rm -rf "$item" &
           done
-
-          end_time=$(date +%s)
-          echo "Removed in $((end_time - start_time)) seconds"
         fi
 
-        echo "Done removing unwanted software."
+        wait
+        overall_end=$(date +%s)
+        echo "Done removing unwanted software in $((overall_end - overall_start)) seconds."
       shell: bash
 
     - name: Run optional diagnostic of top offenders after cleanup

--- a/.github/actions/free-hosted-runner-disk-space/action.yml
+++ b/.github/actions/free-hosted-runner-disk-space/action.yml
@@ -79,7 +79,7 @@ runs:
           local label="$1" path="$2"
           if [[ -d "$path" ]]; then
             echo "Removing $label ($path) in the background..."
-            [[ "$diagnose" == 'true' ]] && du -sh "$path"
+            [[ "$diagnose" == 'true' ]] && du -sh "$path" 2>/dev/null || true
             sudo rm -rf "$path" &
             pids+=("$!")
           else
@@ -105,7 +105,7 @@ runs:
         if [[ -n "$to_remove" ]]; then
           for item in $to_remove; do
             echo "Removing $item in the background..."
-            [[ "$diagnose" == 'true' ]] && du -sh "$item"
+            [[ "$diagnose" == 'true' ]] && du -sh "$item" 2>/dev/null || true
             sudo rm -rf "$item" &
             pids+=("$!")
           done

--- a/.github/actions/free-hosted-runner-disk-space/action.yml
+++ b/.github/actions/free-hosted-runner-disk-space/action.yml
@@ -93,7 +93,6 @@ runs:
         [[ ${{ inputs.remove-codeql }} == 'true' ]] && remove_in_background "CodeQL Action Bundles" "$CODEQL_ROOT"
         [[ ${{ inputs.remove-swift }} == 'true' ]] && remove_in_background "Swift toolchain and libraries" "$SWIFT_ROOT"
         [[ ${{ inputs.remove-powershell }} == 'true' ]] && remove_in_background "PowerShell Core installation" "$POWERSHELL_ROOT"
-
         [[ ${{ inputs.remove-tools-cache }} == 'true' ]] && remove_in_background "tools and dependencies cache" "$AGENT_TOOLSDIRECTORY"
 
         if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -824,7 +824,9 @@ You can override the default behavior by adding one or more of the following inp
 ```
 
 There is an additional input `diagnose-top-offenders-enabled` which when set to `true` will
-run a disk usage analysis and print the top offenders before and after the cleanup.
+run a disk usage analysis and print the top offenders before and after the cleanup, and also
+report the size of each folder before it is removed (this is disabled by default since
+computing it adds a full extra directory scan per folder).
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v18.26.0


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): OPSEXP-4351
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [x] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:
  - #1532
  - #1533

### Description

The `free-hosted-runner-disk-space` action now removes cached tools and dependencies in the background: each folder is deleted in parallel rather than one at a time, and the per-folder `du -sh` size report only runs when `diagnose-top-offenders-enabled` is `true`, since walking the directory tree twice has no benefit otherwise. Each background removal's PID is tracked, so the step fails if any of them errors instead of just checking the last one. The tools-cache directory is removed the same way as everything else, in full; GitHub's toolcache library recreates it on demand. Since the tools-cache directory contains the CodeQL cache as a subdirectory, its size report tolerates files that vanish mid-walk while the CodeQL folder is being deleted in parallel.

### Benchmark

Ran the `Free up disk space on the runner` step 10 times on master (#1532) and 10 times on this branch (#1533) using `gh run rerun` on the `test (ubuntu-latest)` job. `diagnose-top-offenders-enabled` was forced to `false` on both sides, since the diagnostic `du` walk would otherwise mask the real gain.

| Run | master | this PR | diff |
|---|---|---|---|
| 1 | 176s | 125s | +51s |
| 2 | 55s | 67s | −12s |
| 3 | 93s | 67s | +26s |
| 4 | 109s | 24s | +85s |
| 5 | 87s | 28s | +59s |
| 6 | 59s | 69s | −10s |
| 7 | 86s | 65s | +21s |
| 8 | 113s | 111s | +2s |
| 9 | 137s | 75s | +62s |
| 10 | 198s | 28s | +170s |
| **avg** | **111.3s** | **65.9s** | **+45.4s** |
| **median** | **101s** | **67s** | **+34s** |

This branch was faster in 8 of 10 runs, cutting average time by about 41% and median by about 34%. The two regressions were small (12s and 10s) next to wins of up to 170s. Master's times also swung much more (55s to 198s) than this branch's (24s to 125s), which matches what backgrounding the removals should do: total time is now bounded by the slowest single deletion instead of the sum of all of them.
