### PR TITLE
fix(docs): update dead adaptivecards.io link in send-teams-notification docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2447,7 +2447,7 @@ To get the necessary data for mentions:
 
 Beyond the standard card, callers can extend it with their own Adaptive Card content via two optional inputs (both default to an empty array, so existing usages are unaffected):
 
-- `card-actions`: JSON array of [Adaptive Card actions](https://adaptivecards.io/explorer/Action.OpenUrl.html) rendered as buttons at the bottom of the card
+- `card-actions`: JSON array of [Adaptive Card actions](https://learn.microsoft.com/en-us/adaptive-cards/schema-explorer/action-open-url) rendered as buttons at the bottom of the card
 - `card-extra-body`: JSON array of Adaptive Card body elements (e.g. a `FactSet` or a monospace `TextBlock`) appended after the message
 
 Sample usage with custom buttons and body elements:


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): N/A
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested: N/A

### Description

The Action.OpenUrl explorer page moved from adaptivecards.io to Microsoft Learn, so the old link 404s and fails the Links > External check in the docs build. This points the `card-actions` documentation in the send-teams-notification action at the current page instead: https://learn.microsoft.com/en-us/adaptive-cards/schema-explorer/action-open-url

This is a documentation-only fix with no change to any action's behavior, so no release label is needed.