### PR TITLE
AAE-47554 Add shellcheck to actionlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,8 @@ repos:
       - id: actionlint
         args: [-ignore, 'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"']
         exclude: ^(\.github/tests/|\.github/workflows/.*\.lock\.yml$)
+        additional_dependencies:
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
 
   - repo: https://github.com/hyland/github-actions-ensure-sha-pinned-actions
     rev: v1.2.0


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Checklist

- Jira Reference (also in PR title): [AAE-47554](https://hyland.atlassian.net/browse/AAE-47554)
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

- Issue Link: https://hyland.atlassian.net/browse/AAE-47554

Follow-up on the actionlint rollout. This repo already ran `actionlint` at the
latest `v1.7.12` with the `*.lock.yml` exclude, but it was missing the
`go-shellcheck` additional dependency, so inline `run:` scripts in workflows
were never actually shellchecked.

```yaml
additional_dependencies:
  - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
```

`go-shellcheck` is a Wasm build, so contributors get shellcheck coverage
without needing a system `shellcheck` binary.

### Result

No lint fixes were required: `pre-commit run actionlint --all-files` passes
across all workflows with shellcheck enabled. Verified the integration is
genuinely active by temporarily linting a workflow with an unquoted variable,
which correctly reported `SC2086`.

Note that the upstream hook only targets `^\.github/workflows/`, so shell
embedded in composite `.github/actions/**/action.yml` files is still outside
its scope.

Made with [Cursor](https://cursor.com)

[AAE-47554]: https://hyland.atlassian.net/browse/AAE-47554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ