### PR TITLE
Validate CI actionlint shellcheck integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,10 @@ jobs:
       # free-hosted-runner-disk-space action usage and test
       - name: Check available disk space before running free-hosted-runner-disk-space action
         id: free-hosted-runner-disk-space
-        run: echo "total_size_before=$(df --total --output=avail | tail -1)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "total_size_before=$(df --total --output=avail | tail -1)" >> "$GITHUB_OUTPUT"
+          SHELLCHECK_PROBE="some path"
+          ls $SHELLCHECK_PROBE
       - name: Free up disk space on the runner
         uses: ./.github/actions/free-hosted-runner-disk-space
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Show shellcheck provenance
+        run: |
+          which -a shellcheck
+          shellcheck --version
+          dpkg -S "$(which shellcheck)" || true
       - name: pre-commit checks
         uses: ./.github/actions/pre-commit
       - name: Ensure SHA pinned actions


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): none
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Throwaway PR to confirm the CI pre-commit job actually runs actionlint's shellcheck integration, not just the local pre-commit hook. The single commit adds an unquoted shell variable (`ls $SHELLCHECK_PROBE`) to a `run:` step in `.github/workflows/test.yml`, which is only caught via shellcheck (SC2086), not by actionlint's own checks. Local pre-commit already reproduces the failure; this PR exists to verify the same failure surfaces in the CI pre-commit job. Not intended to merge — will be closed after the CI run confirms the result.