### PR TITLE
[benchmark] master with diagnose disabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Free up disk space on the runner
         uses: ./.github/actions/free-hosted-runner-disk-space
         with:
-          diagnose-top-offenders-enabled: 'true'
+          diagnose-top-offenders-enabled: 'false'
       - name: Assert that space available on the runner has increased
         env:
           TOTAL_SIZE_BEFORE: ${{ steps.free-hosted-runner-disk-space.outputs.total_size_before }}


### PR DESCRIPTION
Throwaway benchmark branch to measure free-hosted-runner-disk-space cleanup time on master, with diagnose-top-offenders-enabled forced to false to remove diagnostic overhead. Not for merging, will be closed after data collection.