### PR TITLE
ACS-12680 Simplify s3-upload source selection with a single input

### DIFF
--- a/.github/actions/s3-upload/action.yml
+++ b/.github/actions/s3-upload/action.yml
@@ -8,16 +8,16 @@ inputs:
   aws-role-arn:
     description: AWS role ARN to assume for deployment
     required: true
-  deploy-dir:
-    description: Local directory containing artifacts to upload. Ignored if source-s3-uri is set.
-    required: false
-    default: ./deploy_dir
-  source-s3-uri:
-    description: Source S3 URI to copy from (e.g. s3://bucket/path/). If set, performs S3-to-S3 copy instead of local upload.
+  source:
+    description: Local directory or s3:// URI to copy from. Takes precedence over deploy-dir if both are set.
     required: false
     default: ""
+  deploy-dir:
+    description: "Deprecated: use source instead. Local directory containing artifacts to upload."
+    required: false
+    default: ./deploy_dir
   copy-props:
-    description: Controls whether S3 object metadata is copied during S3-to-S3 copy. Only used when source-s3-uri is set.
+    description: Controls whether S3 object metadata is copied during S3-to-S3 copy. Only used when source is an s3:// URI.
     required: false
     default: "none"
   s3-bucket:
@@ -45,8 +45,8 @@ runs:
     - name: Upload or copy to S3 bucket
       shell: bash
       env:
+        SOURCE: ${{ inputs.source }}
         DEPLOY_DIR: ${{ inputs.deploy-dir }}
-        SOURCE_S3_URI: ${{ inputs.source-s3-uri }}
         COPY_PROPS: ${{ inputs.copy-props }}
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_PATH: ${{ inputs.s3-path }}
@@ -56,10 +56,14 @@ runs:
         else
           s3_destination="s3://${S3_BUCKET}"
         fi
-        if [ -n "${SOURCE_S3_URI}" ]; then
-          echo "Copying from ${SOURCE_S3_URI} to ${s3_destination}"
-          aws s3 cp --acl private --recursive --copy-props "${COPY_PROPS}" "${SOURCE_S3_URI}" "${s3_destination}"
+        if [ -z "${SOURCE}" ]; then
+          echo "::warning::deploy-dir is deprecated, use source instead"
+        fi
+        source_path="${SOURCE:-${DEPLOY_DIR}}"
+        if [[ "${source_path}" == s3://* ]]; then
+          echo "Copying from ${source_path} to ${s3_destination}"
+          aws s3 cp --acl private --recursive --copy-props "${COPY_PROPS}" "${source_path}" "${s3_destination}"
         else
-          echo "Uploading from ${DEPLOY_DIR} to ${s3_destination}"
-          aws s3 cp --acl private --recursive "${DEPLOY_DIR}" "${s3_destination}"
+          echo "Uploading from ${source_path} to ${s3_destination}"
+          aws s3 cp --acl private --recursive "${source_path}" "${s3_destination}"
         fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -2361,18 +2361,33 @@ Resolve preview name based on the PR number and run number:
 
 ### s3-upload
 
-Uploads a local directory of artifacts to an S3 bucket. The caller is responsible for preparing the deploy directory with the artifacts before invoking this action.
+Uploads a local directory of artifacts to an S3 bucket, or copies artifacts from one S3 location to another. The caller is responsible for preparing the deploy directory with the artifacts before invoking this action.
 
 ```yaml
       - uses: Alfresco/alfresco-build-tools/.github/actions/s3-upload@v18.26.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          deploy-dir: ./deploy_dir  # optional, default: ./deploy_dir
+          source: ./deploy_dir  # optional, default: "" (falls back to deploy-dir, default ./deploy_dir); a local path or an s3:// URI
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}
           s3-path: enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
           role-duration-seconds: 3600  # optional, default: 3600
 ```
+
+To copy artifacts between S3 locations instead of uploading from a local directory, set `source` to an `s3://` URI:
+
+```yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/s3-upload@v18.26.0
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          source: s3://staging-bucket/enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
+          copy-props: none  # optional, default: none
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}
+          s3-path: enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
+```
+
+`deploy-dir` is deprecated in favor of `source` but still works as a fallback when `source` is not set.
 
 ### send-teams-notification
 


### PR DESCRIPTION
### Checklist
* Jira Reference (also in PR title): ACS-12680
* [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
* Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
    * [ ] Patch (bugfix)
    * [x] Minor (new feature)
    * [ ] Major (breaking changes)
* External PR link where changes has been tested: N/A (proposed revision on #1530)

### Description

This targets the `feature/ACS-12680-s3-upload-oidc-copy-mode` branch, not master: it's a proposed revision on top of #1530 rather than a separate change.

`source-s3-uri` and `deploy-dir` both answer the same question (what to copy from), so this collapses them into a single `source` input that dispatches on the `s3://` prefix, the same way the `aws s3 cp` CLI distinguishes a local path from an S3 URI. `deploy-dir` keeps working as a deprecated fallback, with a warning emitted when it's relied on, so no existing caller needs to change right away. `docs/README.md` is updated to document the new input, since the current entry doesn't reflect it yet.