### PR TITLE
ACS-12680 Add a single destination input to s3-upload

### DIFF
--- a/.github/actions/s3-upload/action.yml
+++ b/.github/actions/s3-upload/action.yml
@@ -20,12 +20,18 @@ inputs:
     description: Controls whether S3 object metadata is copied during S3-to-S3 copy. Only used when source is an s3:// URI.
     required: false
     default: "none"
+  destination:
+    description: s3:// URI to copy to. Takes precedence over s3-bucket and s3-path if both are set.
+    required: false
+    default: ""
   s3-bucket:
-    description: S3 bucket name
-    required: true
+    description: "Deprecated: use destination instead. S3 bucket name."
+    required: false
+    default: ""
   s3-path:
-    description: Path within the S3 bucket (without leading slash).
-    required: true
+    description: "Deprecated: use destination instead. Path within the S3 bucket (without leading slash)."
+    required: false
+    default: ""
   role-duration-seconds:
     description: Duration in seconds for the assumed AWS role session.
     required: false
@@ -48,13 +54,27 @@ runs:
         SOURCE: ${{ inputs.source }}
         DEPLOY_DIR: ${{ inputs.deploy-dir }}
         COPY_PROPS: ${{ inputs.copy-props }}
+        DESTINATION: ${{ inputs.destination }}
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_PATH: ${{ inputs.s3-path }}
       run: |
-        if [ -n "${S3_PATH}" ]; then
-          s3_destination="s3://${S3_BUCKET}/${S3_PATH}"
+        if [ -n "${DESTINATION}" ]; then
+          s3_destination="${DESTINATION}"
         else
-          s3_destination="s3://${S3_BUCKET}"
+          echo "::warning::s3-bucket and s3-path are deprecated, use destination instead"
+          if [ -z "${S3_BUCKET}" ]; then
+            echo "::error::destination is required"
+            exit 1
+          fi
+          if [ -n "${S3_PATH}" ]; then
+            s3_destination="s3://${S3_BUCKET}/${S3_PATH}"
+          else
+            s3_destination="s3://${S3_BUCKET}"
+          fi
+        fi
+        if [[ "${s3_destination}" != s3://* ]]; then
+          echo "::error::destination must be an s3:// URI, got ${s3_destination}"
+          exit 1
         fi
         if [ -z "${SOURCE}" ]; then
           echo "::warning::deploy-dir is deprecated, use source instead"

--- a/docs/README.md
+++ b/docs/README.md
@@ -2371,25 +2371,23 @@ Uploads a local directory of artifacts to an S3 bucket, or copies artifacts from
           aws-region: ${{ vars.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           source: ./deploy_dir  # optional, default: "" (falls back to deploy-dir, default ./deploy_dir); a local path or an s3:// URI
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}
-          s3-path: enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
+          destination: s3://${{ vars.AWS_S3_BUCKET }}/enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
           role-duration-seconds: 3600  # optional, default: 3600
 ```
 
 To copy artifacts between S3 locations instead of uploading from a local directory, set `source` to an `s3://` URI:
 
 ```yaml
-      - uses: Alfresco/alfresco-build-tools/.github/actions/s3-upload@v18.26.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/s3-upload@v18.27.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           source: s3://staging-bucket/enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
           copy-props: none  # optional, default: none
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}
-          s3-path: enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
+          destination: s3://${{ vars.AWS_S3_BUCKET }}/enterprise/MyProject/MyArtifact/${{ env.RELEASE_VERSION }}
 ```
 
-`deploy-dir` is deprecated in favor of `source` but still works as a fallback when `source` is not set.
+`deploy-dir` is deprecated in favor of `source`, and `s3-bucket`/`s3-path` are deprecated in favor of `destination`; the old inputs still work as a fallback when the new ones are not set.
 
 ### send-teams-notification
 


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): ACS-12680
- [x] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Adds a `destination` input to the `s3-upload` action that takes a full `s3://bucket/path` URI, matching the `source` input from the base PR. `s3-bucket` and `s3-path` are deprecated in favor of `destination` but still work as a fallback, so existing callers are unaffected. The action now fails with a clear error if it can't resolve a destination, or if the resolved destination isn't an `s3://` URI, rather than silently building an invalid path. `docs/README.md` shows `destination` in both examples, and the stale `@v18.26.0` reference in the second example is corrected to `@v18.27.0`.

Stacked on #1530 and targets its branch instead of master, since that PR has a different author.