### PR TITLE
Suggest ruff for Python in pimp-my-repo

### DIFF
--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -122,10 +122,12 @@ If the repo contains non-trivial Python scripts — i.e. more than just CI glue 
 ```
 
 If the repo already lints/formats Python with `black`, `isort`, and/or `flake8`,
-suggest replacing them with `ruff` rather than adding it alongside — ruff supersedes
-all three, so running both is redundant. Only propose this as a separate suggestion
-to the user, since dropping existing hooks is a bigger change than adding a new one;
-don't fold it silently into an unrelated pre-commit change.
+suggest migrating to `ruff` rather than adding it alongside — ruff supersedes all
+three: "Ruff aims to be orders of magnitude faster than alternative tools while
+integrating more functionality behind a single, common interface." Only propose
+this as a separate suggestion to the user, since dropping existing hooks is a
+bigger change than adding a new one; don't fold it silently into an unrelated
+pre-commit change.
 
 ### Wire into CI
 

--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -105,6 +105,25 @@ repos:
         args: [--allowlist, 'Alfresco/alfresco-build-tools/*']
 ```
 
+### Python
+
+If the repo contains non-trivial Python scripts — i.e. more than just CI glue under
+100 lines of code — suggest adding `ruff` for linting and formatting:
+
+```yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.16.6
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+```
+
+### Wire into CI
+
 Wire the config into CI by calling this repo's reusable `pre-commit` action
 ([documented here](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#pre-commit))
 instead of hand-rolling the pre-commit invocation. Use the latest released tag
@@ -152,6 +171,8 @@ in this order and stop at the first match:
 
 In cases 1 and 2, add the same `steps:` shown above as a job named `pre-commit` in the
 existing workflow, keeping its own `on:` triggers untouched.
+
+### Validate locally
 
 Besides wiring pre-commit into CI, check whether `pre-commit` is available locally and
 use it to validate the new hooks before they ever hit CI:

--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -108,7 +108,7 @@ repos:
 ### Python
 
 If the repo contains non-trivial Python scripts — i.e. more than just CI glue under
-100 lines of code — suggest adding `ruff` for linting and formatting. Check the
+100 lines of code — suggest `ruff` for linting and formatting. Check the
 [releases page](https://github.com/astral-sh/ruff-pre-commit/releases) for the latest
 `rev` before adding it:
 
@@ -120,6 +120,12 @@ If the repo contains non-trivial Python scripts — i.e. more than just CI glue 
         args: [ --fix ]
       - id: ruff-format
 ```
+
+If the repo already lints/formats Python with `black`, `isort`, and/or `flake8`,
+suggest replacing them with `ruff` rather than adding it alongside — ruff supersedes
+all three, so running both is redundant. Only propose this as a separate suggestion
+to the user, since dropping existing hooks is a bigger change than adding a new one;
+don't fold it silently into an unrelated pre-commit change.
 
 ### Wire into CI
 

--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -123,11 +123,9 @@ If the repo contains non-trivial Python scripts — i.e. more than just CI glue 
 
 If the repo already lints/formats Python with `black`, `isort`, and/or `flake8`,
 suggest migrating to `ruff` rather than adding it alongside — ruff supersedes all
-three: "Ruff aims to be orders of magnitude faster than alternative tools while
-integrating more functionality behind a single, common interface." Only propose
-this as a separate suggestion to the user, since dropping existing hooks is a
-bigger change than adding a new one; don't fold it silently into an unrelated
-pre-commit change.
+three with a single, much faster tool. Only propose this as a separate suggestion
+to the user, since dropping existing hooks is a bigger change than adding a new
+one; don't fold it silently into an unrelated pre-commit change.
 
 ### Wire into CI
 

--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -108,17 +108,16 @@ repos:
 ### Python
 
 If the repo contains non-trivial Python scripts — i.e. more than just CI glue under
-100 lines of code — suggest adding `ruff` for linting and formatting:
+100 lines of code — suggest adding `ruff` for linting and formatting. Check the
+[releases page](https://github.com/astral-sh/ruff-pre-commit/releases) for the latest
+`rev` before adding it:
 
 ```yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.16.6
     hooks:
-      # Run the linter.
       - id: ruff-check
         args: [ --fix ]
-      # Run the formatter.
       - id: ruff-format
 ```
 


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): none
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

This only changes the `pimp-my-repo` skill's own instructions (`.github/skills/pimp-my-repo/SKILL.md`), not any action or workflow, so no README update or version bump applies.

The pre-commit section of the skill is split into subsections (Python, Wire into CI, Validate locally) so the CI-wiring guidance no longer reads as if it only applies to Python. The Python subsection now suggests adding `ruff-pre-commit` when a target repo's Python scripts go beyond trivial CI glue (more than roughly 100 lines of actual logic), and separately suggests migrating off `black`/`isort`/`flake8` to `ruff` when those are already in use, since ruff supersedes all three.