### PR TITLE
Scope Nexus credentials to the steps that need them in build-and-release-maven

### DIFF
--- a/.github/workflows/build-and-release-maven.yml
+++ b/.github/workflows/build-and-release-maven.yml
@@ -55,10 +55,6 @@ on:
         NEXUS_PASSWORD:
           required: true
 
-env:
-  MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-  MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
 jobs:
   build:
     name: "Build"
@@ -71,9 +67,15 @@ jobs:
           java-distribution: ${{ inputs.java-distribution }}
       - name: "Build"
         if: ${{ inputs.skip-tests }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Build and Test"
         if: ${{ !inputs.skip-tests }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: mvn -B -V install ${{ inputs.build-args }}
 
   compute_release_conditions:
@@ -118,6 +120,12 @@ jobs:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
       - name: "Build"
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: mvn -B -V install -DskipTests ${{ inputs.build-args }}
       - name: "Release"
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: mvn -B -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DskipTests -Darguments="-DskipTests ${{ inputs.release-args }}" ${{ inputs.extra-maven-opts }} release:clean release:prepare release:perform


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): none
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

The `build-and-release-maven` workflow exposed `NEXUS_USERNAME`/`NEXUS_PASSWORD` (as `MAVEN_USERNAME`/`MAVEN_PASSWORD`) through a workflow-level `env` block, which makes them available to every job and step in the workflow, including third-party actions such as `actions/checkout`, `setup-java-build`, and `configure-git-author` that never touch Maven. The credentials are now set as step-level `env` only on the `mvn install`/`release` steps that actually use them, narrowing their exposure without changing the workflow's inputs, outputs, or behavior.