### PR TITLE
Migrate Python linting/formatting to ruff

### DIFF
--- a/.github/tests/python-scripts/shared/fixtures.py
+++ b/.github/tests/python-scripts/shared/fixtures.py
@@ -28,8 +28,7 @@ def _resolve_action_path(config) -> Path:
     candidates = [d for d in resolved_dirs if d.is_dir() and (d / ACTION_FILE).exists()]
     if len(candidates) == 0:
         raise FileNotFoundError(
-            f"Could not find {ACTION_FILE} in any pythonpath entry. "
-            f"pythonpath={python_paths}, resolved={resolved_dirs}"
+            f"Could not find {ACTION_FILE} in any pythonpath entry. pythonpath={python_paths}, resolved={resolved_dirs}"
         )
     if len(candidates) > 1:
         raise RuntimeError(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,23 +70,12 @@ repos:
         args: [--exclude-path, .github/actions/dbp-charts]
         pass_filenames: false
 
-  - repo: https://github.com/psf/black
-    rev: 26.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.6
     hooks:
-      - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 7.0.0
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-pyproject
-          - flake8-quotes
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,19 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
-force-exclude = '''
-.git
-.pytest_cache
-.coverage
-.tox
-.venv
-_build
-buck-out
-build
-dist
-venv
-'''
+extend-exclude = [
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "venv",
+]
 
-[tool.flake8]
-ignore = ['W503', 'E203'] # W503 line break before binary operator - ignored as PEP 8 now recommends this style
-                          # E203 whitespace before ':' - conflicts with Black's slice formatting
-max-line-length = 120
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "C90"]
+ignore = ["E203"] # whitespace before ':' - conflicts with the formatter's slice formatting
+
+[tool.ruff.lint.mccabe]
 max-complexity = 18
-count = true
-exclude = ['venv']
-inline-quotes = "double"
-
-[tool.isort]
-profile="black"


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): none
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [x] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

`.pre-commit-config.yaml` linted and formatted Python with three separate tools (`black`, `isort`, `flake8`). Ruff replaces all three with a single, much faster tool, so this drops the black/isort/flake8 hooks in favor of `ruff-check` and `ruff-format`, and translates the equivalent `pyproject.toml` settings (line length, excludes, ignored rules, max-complexity) into `[tool.ruff]`. This is CI tooling only — no action's inputs, outputs, or behavior changes. `pre-commit run --all-files` passes; the only content change is a single reformatted string in `.github/tests/python-scripts/shared/fixtures.py`.