### PR TITLE
Add digest pinning to pimp-my-repo skill's Dockerfile guidance

### DIFF
--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -13,7 +13,8 @@ already configured correctly; merge rather than overwrite.
 2. **Pre-commit** — a baseline `.pre-commit-config.yaml` with the standard hooks, wired
    into CI via this repo's reusable `pre-commit` action, placed wherever best fits the
    repo's existing workflows.
-3. **SHA-pinning** — every workflow references third-party actions by commit SHA.
+3. **SHA-pinning** — every workflow references third-party actions by commit SHA; any
+   Dockerfile pins its base images by digest.
 4. **Gitignore** — common ignores for the repo's stack, plus Claude Code artifacts.
 5. **AI assistant instructions** — `.github/copilot-instructions.md` with a thin `CLAUDE.md`.
 6. **Secrets & permissions** — least-privilege secret scoping and workflow permissions.
@@ -213,6 +214,27 @@ pre-commit run gha-sha-convert --all-files
 ```
 
 Keep your first-party action refs (e.g. `<OWNER>/<REPO>/*`) on the allowlist only if you intentionally permit version tags for them; otherwise let `gha-sha-convert` pin them too.
+
+### Docker base images
+
+If the repo contains a `Dockerfile`, the same immutability argument applies to its
+`FROM` instructions: a tag like `node:20-bookworm` can move to a different image
+underneath it at any time, so pin the digest alongside the tag.
+
+```dockerfile
+FROM node:20.11.1-bookworm@sha256:1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b
+```
+
+Resolve the digest for the tag currently in use rather than guessing it:
+
+```bash
+docker pull node:20.11.1-bookworm
+docker inspect --format '{{index .RepoDigests 0}}' node:20.11.1-bookworm
+```
+
+Keep the tag in front of the digest (`image:tag@sha256:...`) so the version stays
+human-readable, the same way SHA-pinned actions keep their version as a comment. Apply
+this to every `FROM` line, including multi-stage build stages.
 
 ## 4. Gitignore
 

--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -229,8 +229,11 @@ Resolve the digest for the tag currently in use rather than guessing it:
 
 ```bash
 docker pull node:20.11.1-bookworm
-docker inspect --format '{{index .RepoDigests 0}}' node:20.11.1-bookworm
+docker inspect --format '{{index .RepoDigests 0}}' node:20.11.1-bookworm | cut -d@ -f2
 ```
+
+(`RepoDigests` includes the repo name, e.g. `node@sha256:...`, so `cut` strips it down to
+the bare `sha256:...` that gets pasted after `image:tag@`.)
 
 Keep the tag in front of the digest (`image:tag@sha256:...`) so the version stays
 human-readable, the same way SHA-pinned actions keep their version as a comment. Apply


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): N/A
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Extends the `pimp-my-repo` skill so that when it detects a Dockerfile, it also suggests pinning `FROM` base images by digest, alongside a tag, for the same immutability reasons already applied to third-party GitHub Actions. Includes a resolution snippet (`docker pull` + `docker inspect`) and a note to cover every stage in multi-stage builds.