### PR TITLE
Fix Dependabot silently dropping labels that don't exist yet in pimp-my-repo skill

### DIFF
--- a/.github/skills/pimp-my-repo/SKILL.md
+++ b/.github/skills/pimp-my-repo/SKILL.md
@@ -34,6 +34,18 @@ Rules for every block:
   parent dirs of the marker files (collapse siblings with a glob).
 - Label with `dependencies` plus an ecosystem-specific label.
 
+**Every label referenced must exist in the repo**, or Dependabot silently skips
+labeling the PR and leaves a comment like: *"The following labels could not be found:
+`docker`. Please create it before Dependabot can add it to a pull request."* Check with
+`gh label list`, then create any missing ones before finishing:
+
+```bash
+gh label create docker --description "Docker/Dockerfile dependencies" --color 0db7ed
+```
+
+Pick a description and color that fit the ecosystem; reuse an existing label's color
+scheme if the repo already has similar ones (e.g. other ecosystem labels).
+
 ```yaml
 # Documentation for all configuration options:
 # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference


### PR DESCRIPTION
### Checklist

- Jira Reference (also in PR title): N/A
- [ ] [README](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md) updated after adding/changing behaviour of an action
- Proposed version increment for [release](https://github.com/Alfresco/alfresco-build-tools/blob/master/docs/README.md#release):
  - [ ] Patch (bugfix)
  - [ ] Minor (new feature)
  - [ ] Major (breaking changes)
- External PR link where changes has been tested:

### Description

Dependabot silently drops a label from a PR when that label doesn't exist yet in the target repo, and instead leaves a comment saying the label could not be found (this happened on Alfresco/nexus2cloudsmith#36 for the docker label). This adds a step to the pimp-my-repo skill's Dependabot section that checks for and creates any missing ecosystem labels before finishing setup.